### PR TITLE
feat: support apt proxy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,9 @@ jobs:
             latest,
           ]
 
+    env:
+      TAG: ${{ matrix.tag }}
+
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -79,7 +82,7 @@ jobs:
         run: docker image ls
 
       - name: test
-        run: docker buildx build --progress plain ./test/${{ matrix.tag }}
+        run: docker buildx bake --progress plain build_test
 
   release:
     needs: [lang, distro]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
+      - name: init env
+        run: echo "APT_HTTP_PROXY=http://$(hostname -f):3142" >> $GITHUB_ENV
+
+      - name: start apt-cacher
+        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher && docker run -d -p 3142:3142 apt-cacher
+
       - name: test distro
         run: docker buildx bake --progress plain test
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: start apt-cacher
         run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
 
-      - run: docker ps
+      - run: docker info
 
       - name: test distro
         run: docker buildx bake --progress plain test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ env:
   YARN_PACKAGE_CACHE_KEY: v1
   YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
+  APT_HTTP_PROXY: http://host.docker.internal:3142
 
 jobs:
   distro:
@@ -33,9 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
-
-      - name: init env
-        run: echo "APT_HTTP_PROXY=http://$(hostname -I):3142" >> $GITHUB_ENV
 
       - name: start apt-cacher
         run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: start apt-cacher
-        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
+        run: sudo apt-get install -y apt-cacher-ng
 
       - name: test distro
         run: docker buildx bake --progress plain test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: start apt-cacher
-        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
+        run: sudo apt-get install -y apt-cacher-ng
 
       - name: build
         run: docker buildx bake --progress plain
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: start apt-cacher
-        run: docker buildx build --load --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
+        run: sudo apt-get install -y apt-cacher-ng
 
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         run: echo "APT_HTTP_PROXY=http://$(hostname -f):3142" >> $GITHUB_ENV
 
       - name: start apt-cacher
-        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher && docker run -d -p 3142:3142 apt-cacher
+        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
 
       - name: test distro
         run: docker buildx bake --progress plain test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: start apt-cacher
         run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
 
+      - run: docker ps
+
       - name: test distro
         run: docker buildx bake --progress plain test
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: init env
-        run: echo "APT_HTTP_PROXY=http://$(hostname -f):3142" >> $GITHUB_ENV
+        run: echo "APT_HTTP_PROXY=http://$(hostname -I):3142" >> $GITHUB_ENV
 
       - name: start apt-cacher
         run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ env:
   YARN_PACKAGE_CACHE_KEY: v1
   YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
-  APT_HTTP_PROXY: http://host.docker.internal:3142
+  APT_HTTP_PROXY: http://172.17.0.1:3142
 
 jobs:
   distro:
@@ -37,8 +37,6 @@ jobs:
 
       - name: start apt-cacher
         run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
-
-      - run: docker info
 
       - name: test distro
         run: docker buildx bake --progress plain test
@@ -70,6 +68,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+
+      - name: start apt-cacher
+        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
 
       - name: build
         run: docker buildx bake --progress plain
@@ -110,6 +111,9 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
+
+      - name: start apt-cacher
+        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
 
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: start apt-cacher
-        run: docker buildx build --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
+        run: docker buildx build --load --progress plain -t apt-cacher -f Dockerfile.apt-cacher . && docker run -d -p 3142:3142 apt-cacher
 
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM ubuntu:focal@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da8
 
 ARG USER_ID
 ARG USER_NAME
+ARG APT_HTTP_PROXY
 
 LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
   org.opencontainers.image.source="https://github.com/containerbase/buildpack"

--- a/Dockerfile.apt-cacher
+++ b/Dockerfile.apt-cacher
@@ -5,3 +5,5 @@ RUN    apt-get update && apt-get install -y apt-cacher-ng
 
 EXPOSE 3142
 CMD    chmod 777 /var/cache/apt-cacher-ng && /etc/init.d/apt-cacher-ng start && tail -f /var/log/apt-cacher-ng/*
+
+RUN cat /etc/hosts

--- a/Dockerfile.apt-cacher
+++ b/Dockerfile.apt-cacher
@@ -1,9 +1,0 @@
-FROM ubuntu:focal@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
-
-VOLUME ["/var/cache/apt-cacher-ng"]
-RUN    apt-get update && apt-get install -y apt-cacher-ng
-
-EXPOSE 3142
-CMD    chmod 777 /var/cache/apt-cacher-ng && /etc/init.d/apt-cacher-ng start && tail -f /var/log/apt-cacher-ng/*
-
-RUN cat /etc/hosts

--- a/Dockerfile.apt-cacher
+++ b/Dockerfile.apt-cacher
@@ -1,0 +1,7 @@
+FROM ubuntu:focal@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
+
+VOLUME ["/var/cache/apt-cacher-ng"]
+RUN    apt-get update && apt-get install -y apt-cacher-ng
+
+EXPOSE 3142
+CMD    chmod 777 /var/cache/apt-cacher-ng && /etc/init.d/apt-cacher-ng start && tail -f /var/log/apt-cacher-ng/*

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -11,6 +11,7 @@ FROM ubuntu:bionic@sha256:538529c9d229fb55f50e6746b119e899775205d62c0fc1b7e679b3
 
 ARG USER_ID
 ARG USER_NAME
+ARG APT_HTTP_PROXY
 
 LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
   org.opencontainers.image.source="https://github.com/containerbase/buildpack"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 This repository is the source for the Docker Hub image `containerbase/buildpack`. Commits to `main` branch are automatically built and published.
 
+## Apt proxy
+
+You can pass a custom temporary Apt proxy at build or runtime when installing new packages via `APT_HTTP_PROXY` arg.
+All buildpack tool installer and the `install-apt` command will configure the Proxy for installation and remove it afterwards.
+
 ## Custom base image
 
 To use a custom base image with `containerbase/buildpack` checkout [custom-base-image](./docs/custom-base-image.md) docs.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -27,17 +27,20 @@ group "test" {
 
 target "settings" {
   context = "."
-  cache-from = [
-    "type=registry,ref=ghcr.io/${OWNER}/cache:${FILE}",
-    "type=registry,ref=ghcr.io/${OWNER}/cache:${FILE}-${TAG}",
-  ]
   args = {
     APT_HTTP_PROXY = "${APT_HTTP_PROXY}"
   }
 }
 
+target "cache" {
+  cache-from = [
+    "type=registry,ref=ghcr.io/${OWNER}/cache:${FILE}",
+    "type=registry,ref=ghcr.io/${OWNER}/cache:${FILE}-${TAG}",
+  ]
+}
+
 target "push_cache" {
-  inherits = ["settings"]
+  inherits = ["settings", "cache"]
   output   = ["type=registry"]
   tags = [
     "ghcr.io/${OWNER}/cache:${FILE}-${TAG}",
@@ -47,7 +50,7 @@ target "push_cache" {
 }
 
 target "build_docker" {
-  inherits = ["settings"]
+  inherits = ["settings", "cache"]
   output   = ["type=docker"]
   tags = [
     "ghcr.io/${OWNER}/${FILE}",
@@ -58,14 +61,20 @@ target "build_docker" {
 }
 
 target "build_distro" {
+  inherits = ["settings"]
   dockerfile = "Dockerfile.${TAG}"
   tags = [
     "${OWNER}/${FILE}:${TAG}"
   ]
 }
 
-target "push_ghcr" {
+target "build_test" {
   inherits = ["settings"]
+  context ="./test/${TAG}"
+}
+
+target "push_ghcr" {
+  inherits = ["settings", "cache"]
   output   = ["type=registry"]
   tags = [
     "ghcr.io/${OWNER}/${FILE}",
@@ -74,7 +83,7 @@ target "push_ghcr" {
 }
 
 target "push_hub" {
-  inherits = ["settings"]
+  inherits = ["settings", "cache"]
   output   = ["type=registry"]
   tags     = ["${OWNER}/${FILE}", "${OWNER}/${FILE}:${TAG}"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,6 +31,9 @@ target "settings" {
     "type=registry,ref=ghcr.io/${OWNER}/cache:${FILE}",
     "type=registry,ref=ghcr.io/${OWNER}/cache:${FILE}-${TAG}",
   ]
+  args = {
+    APT_HTTP_PROXY = "${APT_HTTP_PROXY}"
+  }
 }
 
 target "push_cache" {
@@ -56,9 +59,6 @@ target "build_docker" {
 
 target "build_distro" {
   dockerfile = "Dockerfile.${TAG}"
-  args = {
-    APT_HTTP_PROXY = "${APT_HTTP_PROXY}"
-  }
   tags = [
     "${OWNER}/${FILE}:${TAG}"
   ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,6 +8,10 @@ variable "TAG" {
   default = "latest"
 }
 
+variable "APT_HTTP_PROXY" {
+  default = ""
+}
+
 group "default" {
   targets = ["build_docker"]
 }
@@ -52,6 +56,9 @@ target "build_docker" {
 
 target "build_distro" {
   dockerfile = "Dockerfile.${TAG}"
+  args = {
+    APT_HTTP_PROXY = "${APT_HTTP_PROXY}"
+  }
   tags = [
     "${OWNER}/${FILE}:${TAG}"
   ]

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -121,8 +121,14 @@ function check_semver () {
 
 function apt_install () {
   echo "Installing apt packages: ${@}"
+  if [[ "${APT_HTTP_PROXY}" ]]; then
+    echo "Acquire::HTTP::Proxy \"${APT_HTTP_PROXY}\";" | tee -a /etc/apt/apt.conf.d/buildpack-proxy
+    echo "Acquire::HTTPS::Proxy \"DIRECT\";" | tee -a /etc/apt/apt.conf.d/buildpack-proxy
+  fi
   apt-get update
   apt-get install -y "$@"
+
+  rm -f /etc/apt/apt.conf.d/buildpack-proxy
 }
 
 function require_distro () {

--- a/test/dotnet/Dockerfile
+++ b/test/dotnet/Dockerfile
@@ -1,8 +1,6 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as base
 
-ARG APT_HTTP_PROXY
-
 RUN touch /.dummy
 
 WORKDIR /tmp
@@ -14,6 +12,8 @@ COPY --chown=1000:0 test test
 # net3: dotnet 3.1 base image
 #--------------------------------------
 FROM base as net3
+
+ARG APT_HTTP_PROXY
 
 # renovate: datasource=docker lookupName=mcr.microsoft.com/dotnet/sdk versioning=docker
 RUN install-tool dotnet 3.1.409
@@ -44,6 +44,8 @@ RUN set -ex;  \
 # test: dotnet 5.0
 #--------------------------------------
 FROM base as testb
+
+ARG APT_HTTP_PROXY
 
 # renovate: datasource=docker lookupName=mcr.microsoft.com/dotnet/sdk versioning=docker
 RUN install-tool dotnet 5.0.203

--- a/test/dotnet/Dockerfile
+++ b/test/dotnet/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as base
 
+ARG APT_HTTP_PROXY
+
 RUN touch /.dummy
 
 WORKDIR /tmp

--- a/test/erlang/Dockerfile
+++ b/test/erlang/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE}
 
+ARG APT_HTTP_PROXY
+
 # Erlang
 
 #disable renovate: datasource=github-releases lookupName=erlang/otp versioning=loose

--- a/test/golang/Dockerfile
+++ b/test/golang/Dockerfile
@@ -1,7 +1,6 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
-ARG APT_HTTP_PROXY
 
 RUN touch /.dummy
 

--- a/test/golang/Dockerfile
+++ b/test/golang/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 RUN touch /.dummy
 
 WORKDIR /tmp

--- a/test/helm/Dockerfile
+++ b/test/helm/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 
 # renovate: datasource=github-releases lookupName=helm/helm
 RUN install-tool helm v3.5.4

--- a/test/helm/Dockerfile
+++ b/test/helm/Dockerfile
@@ -1,9 +1,6 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
-ARG APT_HTTP_PROXY
-
-
 # renovate: datasource=github-releases lookupName=helm/helm
 RUN install-tool helm v3.5.4
 

--- a/test/java/Dockerfile
+++ b/test/java/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # TODO: only lts
 # renovate: datasource=docker lookupName=openjdk versioning=docker
 RUN install-tool java 11.0.11

--- a/test/java/Dockerfile
+++ b/test/java/Dockerfile
@@ -39,6 +39,7 @@ RUN gradle --version
 #--------------------------------------
 FROM build as testb
 
+ARG APT_HTTP_PROXY
 
 # need to stay old
 RUN install-tool java 8
@@ -48,6 +49,7 @@ RUN install-tool java 8
 #--------------------------------------
 FROM build as testc
 
+ARG APT_HTTP_PROXY
 
 # renovate: datasource=docker lookupName=openjdk versioning=docker
 RUN install-tool java 16.0.1

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -57,6 +57,8 @@ RUN set -ex; \
 #--------------------------------------
 FROM build as testb
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=github-releases depName=containerbase/python-prebuild
 ARG PYTHON_VERSION=3.9.5
 RUN install-tool python
@@ -69,6 +71,8 @@ RUN set -ex; \
 #--------------------------------------
 FROM build as testc
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=docker versioning=docker
 RUN install-tool node 14.17.0
 
@@ -79,6 +83,8 @@ RUN set -ex; \
 # test: php
 #--------------------------------------
 FROM build as testd
+
+ARG APT_HTTP_PROXY
 
 # renovate: datasource=github-releases lookupName=containerbase/python-prebuild
 RUN install-tool php 7.4.14
@@ -92,6 +98,8 @@ RUN set -ex; \
 #--------------------------------------
 FROM build as teste
 
+ARG APT_HTTP_PROXY
+
 # Do not renovate ruby 2.x
 RUN install-tool ruby 2.6.4
 
@@ -104,6 +112,8 @@ RUN set -ex; \
 #--------------------------------------
 FROM build as testf
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=github-releases lookupName=PowerShell/PowerShell
 RUN install-tool powershell v7.1.3
 
@@ -114,6 +124,9 @@ RUN set -ex; cat /etc/hosts; \
 # test: terraform
 #--------------------------------------
 FROM build as testg
+
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=docker lookupName=hashicorp/terraform versioning=docker
 RUN install-tool terraform 0.15.3
 

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 RUN touch /.dummy
 
 # install nginx for request testing

--- a/test/nix/Dockerfile
+++ b/test/nix/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=github-releases lookupName=NixOS/nix
 RUN install-tool nix 2.3.10
 

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -38,6 +38,8 @@ RUN npm --version
 #--------------------------------------
 FROM build as testb
 
+ARG APT_HTTP_PROXY
+
 RUN npm install -g yarn
 
 RUN set -ex; \
@@ -77,6 +79,8 @@ RUN set -ex; \
 
 FROM build as testc
 
+ARG APT_HTTP_PROXY
+
 USER root
 
 # renovate: datasource=npm
@@ -102,6 +106,8 @@ RUN set -ex; \
 #--------------------------------------
 
 FROM ${IMAGE} as testd
+
+ARG APT_HTTP_PROXY
 
 # renovate: datasource=npm
 RUN install-tool node 15.0.1

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=docker versioning=docker
 RUN install-tool node 14.17.0
 

--- a/test/php/Dockerfile
+++ b/test/php/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as base
 
+ARG APT_HTTP_PROXY
+
 RUN touch /.dummy
 
 WORKDIR /tmp

--- a/test/php/Dockerfile
+++ b/test/php/Dockerfile
@@ -1,8 +1,6 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as base
 
-ARG APT_HTTP_PROXY
-
 RUN touch /.dummy
 
 WORKDIR /tmp
@@ -13,6 +11,8 @@ COPY --chown=1000:0 test test
 # test: php 7.4
 #--------------------------------------
 FROM base as testa
+
+ARG APT_HTTP_PROXY
 
 # old php version, not for renovating
 RUN install-tool php 7.4.14
@@ -50,6 +50,8 @@ RUN set -ex; \
 #--------------------------------------
 FROM base as testb
 
+ARG APT_HTTP_PROXY
+
 # old php version, not for renovating
 RUN install-tool php 5.6.40
 
@@ -80,6 +82,8 @@ RUN composer --version
 # test: php 8.0
 #--------------------------------------
 FROM base as testc
+
+ARG APT_HTTP_PROXY
 
 # no auto env for testing
 SHELL [ "/bin/sh", "-c" ]

--- a/test/powershell/Dockerfile
+++ b/test/powershell/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=github-releases lookupName=PowerShell/PowerShell
 RUN install-tool powershell v7.1.3
 

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -1,9 +1,6 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as base
 
-ARG APT_HTTP_PROXY
-
-
 RUN touch /.dummy
 
 WORKDIR /tmp
@@ -11,12 +8,16 @@ COPY --chown=1000:0 test test
 
 FROM base as build
 
+ARG APT_HTTP_PROXY
+
 # Python
 # renovate: datasource=github-releases lookupName=containerbase/python-prebuild
 RUN install-tool python 3.9.5
 
 
 FROM base as build-rootless
+
+ARG APT_HTTP_PROXY
 
 USER 1000
 

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as base
 
+ARG APT_HTTP_PROXY
+
 
 RUN touch /.dummy
 

--- a/test/ruby/Dockerfile
+++ b/test/ruby/Dockerfile
@@ -14,6 +14,8 @@ COPY --chown=1000:0 test test
 
 FROM ${IMAGE} as build3
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=github-releases lookupName=containerbase/ruby-prebuild versioning=ruby
 RUN install-tool ruby 3.0.1
 

--- a/test/ruby/Dockerfile
+++ b/test/ruby/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # Do not renovate ruby 2.x
 RUN install-tool ruby 2.6.4
 

--- a/test/rust/Dockerfile
+++ b/test/rust/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=docker versioning=docker
 RUN install-tool rust 1.52.1
 

--- a/test/swift/Dockerfile
+++ b/test/swift/Dockerfile
@@ -1,6 +1,8 @@
 ARG IMAGE=containerbase/buildpack
 FROM ${IMAGE} as build
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=docker versioning=docker
 RUN install-tool swift 5.4.0
 

--- a/test/swift/Dockerfile
+++ b/test/swift/Dockerfile
@@ -42,6 +42,8 @@ RUN swift --version
 #--------------------------------------
 FROM build as testb
 
+ARG APT_HTTP_PROXY
+
 # renovate: datasource=docker versioning=docker
 RUN install-tool swift 5.4.0
 


### PR DESCRIPTION
Allow passing `APT_HTTP_PROXY` to configure a temporary apt proxy while building buildpack based images.

CI is using a local proxy to speedup parallel and multiple downloads.
Maybe we can use github cache to speedup more in a later pr.