### PR TITLE
ci: switch apt proxy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,8 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: start apt-cacher
-        run: sudo apt-get install -y apt-cacher-ng
+      - name: start squid-deb-proxy
+        run: sudo apt-get install -y squid-deb-proxy
 
       - name: build
         run: docker buildx bake --progress plain
@@ -114,8 +114,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: start apt-cacher
-        run: sudo apt-get install -y apt-cacher-ng
+      - name: start squid-deb-proxy
+        run: sudo apt-get install -y squid-deb-proxy
 
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,9 +132,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: prepare apt proxy
-        run: sudo yarn prepare:proxy
-
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'
         run: |
@@ -149,6 +146,9 @@ jobs:
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
+
+      - name: prepare apt proxy
+        run: sudo yarn prepare:proxy
 
       - name: semantic-release
         if: github.event_name == 'push'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: prepare apt proxy
-        run: yarn prepare:proxy
+        run: sudo yarn prepare:proxy
 
       - name: test distro
         run: docker buildx bake --progress plain test-distro
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: prepare apt proxy
-        run: yarn prepare:proxy
+        run: sudo yarn prepare:proxy
 
       - name: build
         run: docker buildx bake --progress plain
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
 
       - name: prepare apt proxy
-        run: yarn prepare:proxy
+        run: sudo yarn prepare:proxy
 
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: start squid-deb-proxy
-        run: sudo apt-get install -y squid-deb-proxy
+      - name: prepare apt proxy
+        run: yarn prepare:proxy
 
       - name: test distro
         run: docker buildx bake --progress plain test-distro
@@ -70,8 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: start squid-deb-proxy
-        run: sudo apt-get install -y squid-deb-proxy
+      - name: prepare apt proxy
+        run: yarn prepare:proxy
 
       - name: build
         run: docker buildx bake --progress plain
@@ -114,8 +114,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: start squid-deb-proxy
-        run: sudo apt-get install -y squid-deb-proxy
+      - name: prepare apt proxy
+        run: yarn prepare:proxy
 
       - name: Docker registry login
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ env:
   YARN_PACKAGE_CACHE_KEY: v1
   YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
-  APT_HTTP_PROXY: http://172.17.0.1:3142
+  APT_HTTP_PROXY: http://172.17.0.1:8000
 
 jobs:
   distro:
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: start apt-cacher
-        run: sudo apt-get install -y apt-cacher-ng
+      - name: start squid-deb-proxy
+        run: sudo apt-get install -y squid-deb-proxy
 
       - name: test distro
         run: docker buildx bake --progress plain test-distro

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
+      - name: Cache Yarn packages
+        uses: actions/cache@v2.1.6
+        with:
+          path: ${{ env.YARN_CACHE_FOLDER }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
+
       - name: prepare apt proxy
         run: sudo yarn prepare:proxy
 
@@ -69,6 +78,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+
+      - name: Cache Yarn packages
+        uses: actions/cache@v2.1.6
+        with:
+          path: ${{ env.YARN_CACHE_FOLDER }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
 
       - name: prepare apt proxy
         run: sudo yarn prepare:proxy

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -67,9 +67,6 @@ target "build-docker" {
 target "build-distro" {
   inherits = ["settings"]
   dockerfile = "Dockerfile.${TAG}"
-  tags = [
-    "${OWNER}/${FILE}:${TAG}"
-  ]
 }
 
 target "build-test" {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "run-s release:prepare",
-    "prepare:proxy": "sudo node tools/prepare-proxy.js",
+    "prepare:proxy": "node tools/prepare-proxy.js",
     "release:prepare": "node tools/prepare-release.js",
     "release:publish": "node tools/publish-release.js"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "build": "run-s release:prepare",
+    "prepare:proxy": "sudo node tools/prepare-proxy.js",
     "release:prepare": "node tools/prepare-release.js",
     "release:publish": "node tools/publish-release.js"
   },

--- a/tools/buildpack.acl
+++ b/tools/buildpack.acl
@@ -1,0 +1,1 @@
+ppa.launchpad.net

--- a/tools/buildpack.acl
+++ b/tools/buildpack.acl
@@ -1,1 +1,2 @@
 ppa.launchpad.net
+binaries.erlang-solutions.com

--- a/tools/prepare-proxy.js
+++ b/tools/prepare-proxy.js
@@ -1,0 +1,9 @@
+import shell from 'shelljs';
+
+shell.echo(`Preparing squid-deb-proxy`);
+
+shell.exec('apt-get install -y squid-deb-proxy');
+shell
+  .cat('./tools/buildpack.acl')
+  .to('/etc/squid-deb-proxy/mirror-dstdomain.acl.d/buildpack.acl');
+shell.exec('systemctl reload squid-deb-proxy');


### PR DESCRIPTION
- use squid-deb-proxy instead of apt-cacher-ng
- do not export distro image to docker, saves ~1m (~10%) build time