### PR TITLE
fix: use apt proxy for https

### DIFF
--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -123,7 +123,6 @@ function apt_install () {
   echo "Installing apt packages: ${@}"
   if [[ "${APT_HTTP_PROXY}" ]]; then
     echo "Acquire::HTTP::Proxy \"${APT_HTTP_PROXY}\";" | tee -a /etc/apt/apt.conf.d/buildpack-proxy
-    echo "Acquire::HTTPS::Proxy \"DIRECT\";" | tee -a /etc/apt/apt.conf.d/buildpack-proxy
   fi
   apt-get -qq update
   apt-get -qq install -y "$@"


### PR DESCRIPTION
`squid-deb-proxy` also supports proxying https apt sources, so no need for direct connection.

This works fine on my local ubuntu machines