### PR TITLE
feat: support ignore tools by arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,25 @@ To use a custom base image with `containerbase/buildpack` checkout [custom-base-
 ### Custom Root CA Certificates
 
 To add custom root certifactes to the `containerbase/buildpack` base image checkout [custom-root-ca](./docs/custom-root-ca.md) docs.
+
+### Temporary disable tool installer
+
+To temporary disable / skip some tool installer set the build arg `IGNORED_TOOLS` to a comma separated case-insensitive tool names list.
+
+The following sample will skip the installation of `powershell` and `node`.
+
+```Dockerfile
+FROM containerbase/buildpack
+
+ARG IGNORED_TOOLS=powershell,node
+
+
+# renovate: datasource=github-releases lookupName=PowerShell/PowerShell
+RUN install-tool powershell v7.1.3
+
+# renovate: datasource=docker versioning=docker
+RUN install-tool node 14.17.3
+
+# renovate: datasource=github-releases lookupName=moby/moby
+RUN install-tool docker 20.10.7
+```

--- a/src/usr/local/bin/install-tool
+++ b/src/usr/local/bin/install-tool
@@ -14,6 +14,11 @@ if [[ ! -f "$TOOL" ]]; then
   exit 1;
 fi
 
+if [[ $(ignore_tool) -eq 1 ]]; then
+  echo "Tool ignored - skipping: ${TOOL_NAME}"
+  exit 0;
+fi
+
 
 echo "Installing tool ${TOOL_NAME} v${TOOL_VERSION}"
 . $TOOL

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -206,3 +206,8 @@ function find_tool_path () {
     echo ${USER_HOME}/${TOOL_NAME}/${TOOL_VERSION}
   fi
 }
+
+ignore_tool() {
+    local tools=${IGNORED_TOOLS,,}
+    [[ $tools =~ (^|,)$TOOL_NAME($|,) ]] && echo 1 || echo 0
+}

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -154,6 +154,24 @@ WORKDIR /tmp
 RUN TF_PLUGIN_CACHE_DIR=$HOME/.tf-cache terraform init
 
 #--------------------------------------
+# test: ignore tools
+#--------------------------------------
+FROM build as testh
+
+ARG APT_HTTP_PROXY
+
+ARG IGNORED_TOOLS=powershell,node
+
+# renovate: datasource=github-releases lookupName=PowerShell/PowerShell
+RUN install-tool powershell v7.1.3
+
+# renovate: datasource=docker versioning=docker
+RUN install-tool node 14.17.3
+
+# renovate: datasource=github-releases lookupName=moby/moby
+RUN install-tool docker 20.10.7
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM ${IMAGE}
@@ -165,3 +183,4 @@ COPY --from=testd /.dummy /.dummy
 COPY --from=teste /.dummy /.dummy
 COPY --from=testf /.dummy /.dummy
 COPY --from=testg /.dummy /.dummy
+COPY --from=testh /.dummy /.dummy


### PR DESCRIPTION
Allows to disable tool installation via build arg: `ARG IGNORED_TOOLS=powershell,node`.

closes #54