### PR TITLE
feat(java): add jre variant installer

### DIFF
--- a/src/usr/local/buildpack/tools/java-jre.sh
+++ b/src/usr/local/buildpack/tools/java-jre.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+check_semver $TOOL_VERSION
+
+if [[ ! "${MAJOR}" || ! "${MINOR}" || ! "${PATCH}" ]]; then
+  echo Invalid version: ${TOOL_VERSION}
+  exit 1
+fi
+
+tool_path=$(find_tool_path)
+
+function update_env () {
+  reset_tool_env
+  export_tool_env JAVA_HOME "${1}"
+  export_tool_path "${1}/bin"
+}
+
+if [[ -z "${tool_path}" ]]; then
+  INSTALL_DIR=$(get_install_dir)
+  base_path=${INSTALL_DIR}/${TOOL_NAME}
+  tool_path=${base_path}/${TOOL_VERSION}
+
+  mkdir -p ${tool_path}
+
+  file=/tmp/java.tgz
+
+  ARCH=x64
+  URL=https://api.adoptium.net/v3/assets/version
+  API_ARGS='heap_size=normal&image_type=jre&os=linux&page=0&page_size=1&project=jdk&vendor=adoptium'
+
+  BIN_URL=$(curl -sSLf -H 'accept: application/json' "${URL}/${TOOL_VERSION}?architecture=${ARCH}&${API_ARGS}" \
+    | jq --raw-output '.[0].binaries[0].package.link')
+
+  curl -sSfLo ${file} ${BIN_URL}
+  tar --strip 1 -C ${tool_path} -xf ${file}
+  rm ${file}
+
+  update_env ${tool_path}
+
+  shell_wrapper java
+else
+  echo "Already installed, resetting env"
+  update_env ${tool_path}
+fi
+
+java -version

--- a/test/java/Dockerfile
+++ b/test/java/Dockerfile
@@ -45,7 +45,10 @@ RUN gradle --version
 #--------------------------------------
 # test: gradle 7
 #--------------------------------------
-FROM build as testb
+FROM base as testb
+
+# renovate: datasource=adoptium-java
+RUN install-tool java-jre 11.0.12+7
 
 # renovate: datasource=gradle-version versioning=gradle
 RUN install-tool gradle 7.2


### PR DESCRIPTION
You can now install only the JRE part (only java 8 and java 11, SO LTS only)

* v8  JRE is ~40MB where the JDK is ~80MB
* v11 JRE is ~40MB where the JDK is ~180MB