### PR TITLE
fix: npm non-root install

### DIFF
--- a/src/usr/local/buildpack/tools/npm.sh
+++ b/src/usr/local/buildpack/tools/npm.sh
@@ -10,9 +10,13 @@ fi
 
 npm install -g npm@${TOOL_VERSION}
 
+hash -d npm
+
 npm --version
 
 # Clean download cache
 npm cache clean --force
 # Clean node-gyp cache
-rm -rf /root/.cache
+if [[ $EUID -eq 0 ]]; then
+  rm -rf /root/.cache
+fi


### PR DESCRIPTION
Before:

```
ubuntu@ab818ffd2bfa:/$ install-tool npm 6.14.3
Installing tool npm v6.14.3

added 1 package, and audited 436 packages in 7s

1 package is looking for funding
  run `npm fund` for details

22 vulnerabilities (1 low, 15 moderate, 6 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm notice
npm notice New patch version of npm available! 8.1.0 -> 8.1.3
npm notice Changelog: https://github.com/npm/cli/releases/tag/v8.1.3
npm notice Run npm install -g npm@8.1.3 to update!
npm notice
8.1.0
npm WARN using --force Recommended protections disabled.
rm: cannot remove '/root/.cache': Permission denied
ubuntu@ab818ffd2bfa:/$ npm --version
6.14.3
ubuntu@ab818ffd2bfa:/$
```

After:

```
user@c548770e177a:/$ npm --version
8.1.0
user@c548770e177a:/$ install-tool npm 6.14.3
Installing tool npm v6.14.3

added 1 package, and audited 436 packages in 7s

1 package is looking for funding
  run `npm fund` for details

22 vulnerabilities (1 low, 15 moderate, 6 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm notice 
npm notice New patch version of npm available! 8.1.0 -> 8.1.3
npm notice Changelog: https://github.com/npm/cli/releases/tag/v8.1.3
npm notice Run npm install -g npm@8.1.3 to update!
npm notice 
6.14.3
npm WARN using --force I sure hope you know what you are doing.
user@c548770e177a:/$ npm --version
8.1.0
user@c548770e177a:/$ hash -d npm
user@c548770e177a:/$ npm --version
6.14.3
```