### PR TITLE
feat: update env handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
   org.opencontainers.image.source="https://github.com/containerbase/buildpack"
 
 #  autoloading buildpack env
-ENV BASH_ENV=/usr/local/etc/env
+ENV BASH_ENV=/usr/local/etc/env ENV=/usr/local/etc/env PATH=/home/user/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docs/custom-base-image.md
+++ b/docs/custom-base-image.md
@@ -21,7 +21,7 @@ FROM amd64/ubuntu:focal as base
 ARG APT_HTTP_PROXY
 
 # Set env and shell
-ENV BASH_ENV=/usr/local/etc/env
+ENV BASH_ENV=/usr/local/etc/env ENV=/usr/local/etc/env PATH=/home/$USER_NAME/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 
 # This entry point ensures that dumb-init is run

--- a/docs/custom-base-image.md
+++ b/docs/custom-base-image.md
@@ -67,7 +67,7 @@ ARG USER_ID=1005
 ARG APT_HTTP_PROXY
 
 # Set env and shell
-ENV BASH_ENV=/usr/local/etc/env
+ENV BASH_ENV=/usr/local/etc/env ENV=/usr/local/etc/env PATH=/home/$USER_NAME/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 
 # This entry point ensures that dumb-init is run

--- a/src/usr/local/bin/docker-entrypoint.sh
+++ b/src/usr/local/bin/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [[ -f "$BASH_ENV" && -z "${BUILDPACK+x}" ]]; then
-  . $BASH_ENV
+if [[ -f "/usr/local/etc/env" && -z "${BUILDPACK+x}" ]]; then
+  . /usr/local/etc/env
 fi
 
 exec dumb-init -- "$@"

--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -23,11 +23,6 @@ if [[ -z "${USER_ID+x}" ]]; then
   echo "No USER_ID defined - using: ${USER_ID}"
 fi
 
-if [[ -z "${BASH_ENV+x}" ]]; then
-  echo "No BASH_ENV defined - skipping: ${BASH_ENV}"
-  exit 1;
-fi
-
 
 # env helper, loads tool specific env
 cat >> $ENV_FILE <<- EOM

--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -23,6 +23,11 @@ if [[ -z "${USER_ID+x}" ]]; then
   echo "No USER_ID defined - using: ${USER_ID}"
 fi
 
+if [[ "${BASH_ENV}" != "${ENV_FILE}" ]]; then
+  echo "Wrong BASH_ENV defined - skipping: ${BASH_ENV}"
+  exit 1;
+fi
+
 
 # env helper, loads tool specific env
 cat >> $ENV_FILE <<- EOM

--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -30,7 +30,7 @@ fi
 
 
 # env helper, loads tool specific env
-cat >> $BASH_ENV <<- EOM
+cat >> $ENV_FILE <<- EOM
 export BUILDPACK=1 USER_NAME="${USER_NAME}" USER_ID="${USER_ID}" USER_HOME="/home/${USER_NAME}" PATH="/home/${USER_NAME}/bin:\${PATH}"
 
 # openshift override unknown user home
@@ -57,8 +57,8 @@ fi
 EOM
 
 cat >> /etc/bash.bashrc <<- EOM
-if [[ -f "$BASH_ENV" && -z "${BUILDPACK+x}" ]]; then
-  . $BASH_ENV
+if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
+  . $ENV_FILE
 fi
 EOM
 

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+export ENV_FILE=/usr/local/etc/env
+
 function refreshenv () {
-  if [[ -r $BASH_ENV ]]; then
-    . $BASH_ENV
+  if [[ -r "$ENV_FILE" ]]; then
+    . $ENV_FILE
   fi
 }
 
@@ -12,12 +14,12 @@ fi
 
 function export_env () {
   export "${1}=${2}"
-  echo export "${1}=\${${1}-${2}}" >> $BASH_ENV
+  echo export "${1}=\${${1}-${2}}" >> $ENV_FILE
 }
 
 function export_path () {
   export PATH="$1:$PATH"
-  echo export PATH="$1:\$PATH" >> $BASH_ENV
+  echo export PATH="$1:\$PATH" >> $ENV_FILE
 }
 
 function reset_tool_env () {
@@ -61,8 +63,8 @@ function shell_wrapper () {
   cat > $FILE <<- EOM
 #!/bin/bash
 
-if [[ -f "\$BASH_ENV" && -z "${BUILDPACK+x}" ]]; then
-  . \$BASH_ENV
+if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
+  . $ENV_FILE
 fi
 
 if [[ "\$(command -v ${1})" == "$FILE" ]]; then

--- a/test/Dockerfile.bionic
+++ b/test/Dockerfile.bionic
@@ -9,7 +9,7 @@ LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
   org.opencontainers.image.source="https://github.com/containerbase/buildpack"
 
 #  autoloading buildpack env
-ENV BASH_ENV=/usr/local/etc/env
+ENV BASH_ENV=/usr/local/etc/env ENV=/usr/local/etc/env PATH=/home/$USER_NAME/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 
 COPY src/ /

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -130,7 +130,7 @@ ARG USER_ID=1005
 ARG APT_HTTP_PROXY
 
 # Set env and shell
-ENV BASH_ENV=/usr/local/etc/env
+ENV BASH_ENV=/usr/local/etc/env PATH=/home/$USER_NAME/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 
 COPY --from=build /test/ca.pem /usr/local/share/ca-certificates/renovate-ca.crt
@@ -148,6 +148,8 @@ RUN openssl verify /renovate.pem
 RUN touch /.dummy
 
 USER ${USER_ID}
+
+SHELL ["/bin/sh", "-c"]
 
 # renovate: datasource=docker lookupName=hashicorp/terraform versioning=docker
 RUN install-tool terraform 1.0.11


### PR DESCRIPTION
* Instead of relying on `BASH_ENV` we now use the known `ENV_FILE=/usr/local/etc/env` path
* Add `/home/<user>/bin` to default path
* Add `ENV=/usr/local/etc/env` for interactive dash shell (default /bin/sh`)