### PR TITLE
feat(node): use symlinks for tools

### DIFF
--- a/src/usr/local/bin/install-npm
+++ b/src/usr/local/bin/install-npm
@@ -4,16 +4,26 @@ set -e
 
 . /usr/local/buildpack/util.sh
 
-require_root
+require_user
 require_tool "$@"
-check_command npm
 
-unset NPM_CONFIG_PREFIX
+case "$TOOL_NAME" in
+  npm | yarn | pnpm | lerna)
+    install-tool $TOOL_NAME ${TOOL_VERSION}
+    ;;
 
-echo "Installing npm tool ${TOOL_NAME} v${TOOL_VERSION}"
-npm install --global ${TOOL_NAME}@${TOOL_VERSION} --unsafe
+  *)
+    require_root
+    check_command npm
+    unset NPM_CONFIG_PREFIX
 
-# Clean download cache
-npm cache clean --force
-# Clean node-gyp cache
-rm -rf /root/.cache
+    echo "Installing npm tool ${TOOL_NAME} v${TOOL_VERSION}"
+    npm install ${TOOL_NAME}@${TOOL_VERSION} --global --unsafe --cache /tmp/empty-cache
+
+    # Clean download cache
+    npm cache clean --force
+    # Clean node-gyp cache
+    rm -rf /root/.cache /tmp/empty-cache
+    ;;
+esac
+

--- a/src/usr/local/buildpack/tools/lerna.sh
+++ b/src/usr/local/buildpack/tools/lerna.sh
@@ -7,8 +7,8 @@ check_command node
 tool_path=$(find_tool_path)
 
 function update_env () {
-  reset_tool_env
-  export_tool_path "${1}/bin"
+  PATH="${1}/bin:${PATH}"
+  link_wrapper ${TOOL_NAME}
 }
 
 if [[ -z "${tool_path}" ]]; then
@@ -26,7 +26,6 @@ if [[ -z "${tool_path}" ]]; then
   rm -rf $HOME/.cache /tmp/empty-cache
 
   update_env ${tool_path}
-  shell_wrapper ${TOOL_NAME}
 else
   echo "Already installed, resetting env"
   update_env ${tool_path}

--- a/src/usr/local/buildpack/tools/node.sh
+++ b/src/usr/local/buildpack/tools/node.sh
@@ -10,13 +10,13 @@ if [[ ! "${MAJOR}" || ! "${MINOR}" ]]; then
   exit 1
 fi
 
+NODE_DISTRO=linux-x64
+NODE_INSTALL_DIR=/usr/local/node/${TOOL_VERSION}
+
 if [[ -d "${NODE_INSTALL_DIR}" ]]; then
   echo "Skipping, already installed"
   exit 0
 fi
-
-NODE_DISTRO=linux-x64
-NODE_INSTALL_DIR=/usr/local/node/${TOOL_VERSION}
 
 function update_env () {
   PATH="${1}/bin:${PATH}"

--- a/src/usr/local/buildpack/tools/node.sh
+++ b/src/usr/local/buildpack/tools/node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 require_root
 check_semver $TOOL_VERSION

--- a/src/usr/local/buildpack/tools/node.sh
+++ b/src/usr/local/buildpack/tools/node.sh
@@ -26,7 +26,8 @@ curl -sLo node.tar.xz https://nodejs.org/dist/v${TOOL_VERSION}/node-v${TOOL_VERS
 tar -C ${NODE_INSTALL_DIR} --strip 1 -xf node.tar.xz
 rm node.tar.xz
 
-export_tool_path "${NODE_INSTALL_DIR}/bin"
+#export_tool_path "${NODE_INSTALL_DIR}/bin"
+PATH="${NODE_INSTALL_DIR}/bin:${PATH}"
 
 if [[ ${MAJOR} < 15 ]]; then
   # update to latest node-gyp to fully support python3
@@ -49,8 +50,8 @@ chmod -R g+w $NPM_CONFIG_PREFIX
 export_env NPM_CONFIG_PREFIX $NPM_CONFIG_PREFIX
 export_path "\$NPM_CONFIG_PREFIX/bin"
 
-shell_wrapper node
-shell_wrapper npm
+link_wrapper node
+link_wrapper npm
 
 # Clean download cache
 npm cache clean --force

--- a/src/usr/local/buildpack/tools/npm.sh
+++ b/src/usr/local/buildpack/tools/npm.sh
@@ -7,8 +7,8 @@ check_command node
 tool_path=$(find_tool_path)
 
 function update_env () {
-  reset_tool_env
-  export_tool_path "${1}/bin"
+  PATH="${1}/bin:${PATH}"
+  link_wrapper ${TOOL_NAME}
 }
 
 if [[ -z "${tool_path}" ]]; then

--- a/src/usr/local/buildpack/tools/npm.sh
+++ b/src/usr/local/buildpack/tools/npm.sh
@@ -4,11 +4,19 @@ set -e
 
 check_command node
 
+check_semver $TOOL_VERSION
+
+if [[ ! "${MAJOR}" || ! "${MINOR}" ]]; then
+  echo Invalid version: ${TOOL_VERSION}
+  exit 1
+fi
+
 tool_path=$(find_tool_path)
 
 function update_env () {
   PATH="${1}/bin:${PATH}"
   link_wrapper ${TOOL_NAME}
+  link_wrapper npx
 }
 
 if [[ -z "${tool_path}" ]]; then
@@ -19,6 +27,12 @@ if [[ -z "${tool_path}" ]]; then
   mkdir -p ${tool_path}
 
   NPM_CONFIG_PREFIX=$tool_path npm install --cache /tmp/empty-cache -g npm@${TOOL_VERSION}
+
+  if [[ ${MAJOR} < 7 ]]; then
+    # update to latest node-gyp to fully support python3
+    npm explore npm -g -- npm install --cache /tmp/empty-cache node-gyp@latest
+    rm -rf /tmp/empty-cache
+  fi
 
   # Clean download cache
   NPM_CONFIG_PREFIX=$tool_path npm cache clean --force

--- a/src/usr/local/buildpack/tools/pnpm.sh
+++ b/src/usr/local/buildpack/tools/pnpm.sh
@@ -7,8 +7,8 @@ check_command node
 tool_path=$(find_tool_path)
 
 function update_env () {
-  reset_tool_env
-  export_tool_path "${1}/bin"
+  PATH="${1}/bin:${PATH}"
+  link_wrapper ${TOOL_NAME}
 }
 
 if [[ -z "${tool_path}" ]]; then
@@ -26,7 +26,6 @@ if [[ -z "${tool_path}" ]]; then
   rm -rf $HOME/.cache /tmp/empty-cache
 
   update_env ${tool_path}
-  shell_wrapper ${TOOL_NAME}
 else
   echo "Already installed, resetting env"
   update_env ${tool_path}

--- a/src/usr/local/buildpack/tools/yarn.sh
+++ b/src/usr/local/buildpack/tools/yarn.sh
@@ -7,8 +7,8 @@ check_command node
 tool_path=$(find_tool_path)
 
 function update_env () {
-  reset_tool_env
-  export_tool_path "${1}/bin"
+  PATH="${1}/bin:${PATH}"
+  link_wrapper ${TOOL_NAME}
 }
 
 if [[ -z "${tool_path}" ]]; then
@@ -26,7 +26,6 @@ if [[ -z "${tool_path}" ]]; then
   rm -rf $HOME/.cache /tmp/empty-cache
 
   update_env ${tool_path}
-  shell_wrapper ${TOOL_NAME}
 else
   echo "Already installed, resetting env"
   update_env ${tool_path}

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -67,8 +67,6 @@ if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
   . $ENV_FILE
 fi
 
-echo PATH=\$PATH
-
 if [[ "\$(command -v ${1})" == "$FILE" ]]; then
   echo Could not forward ${1}, probably wrong PATH variable. >&2
   echo PATH=\$PATH

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -55,7 +55,7 @@ function export_tool_path () {
 }
 
 
-# use this if custom env is required, creates a shell wrapper to /usr/local/bin
+# use this if custom env is required, creates a shell wrapper to /usr/local/bin or /home/<user>/bin
 function shell_wrapper () {
   local install_dir=$(get_install_dir)
   local FILE="${install_dir}/bin/${1}"
@@ -66,6 +66,8 @@ function shell_wrapper () {
 if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
   . $ENV_FILE
 fi
+
+echo PATH=\$PATH
 
 if [[ "\$(command -v ${1})" == "$FILE" ]]; then
   echo Could not forward ${1}, probably wrong PATH variable. >&2
@@ -78,7 +80,7 @@ EOM
   chmod +x $FILE
 }
 
-# use this for simple symlink to /usr/local/bin
+# use this for simple symlink to /usr/local/bin or /home/<user>/bin
 function link_wrapper () {
   local install_dir=$(get_install_dir)
   local TARGET="${install_dir}/bin/${1}"

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -92,13 +92,8 @@ FROM build as testc
 
 ARG APT_HTTP_PROXY
 
-USER root
-
 # renovate: datasource=npm
 RUN install-tool pnpm 6.23.1
-
-USER 1000
-
 
 RUN set -ex; \
   pnpm --version;
@@ -110,7 +105,7 @@ RUN set -ex; cd a; pnpm i
 SHELL [ "/bin/sh", "-c" ]
 RUN set -ex; \
   pnpm --version \
-  [ "$(command -v pnpm)" = "/usr/local/bin/pnpm" ] && echo "works" || exit 1;
+  [ "$(command -v pnpm)" = "/home/${USER_NAME}/bin/pnpm" ] && echo "works" || exit 1;
 
 #--------------------------------------
 # test: node 17
@@ -154,35 +149,72 @@ RUN set -ex; \
 
 
 #--------------------------------------
-# test: npm (user)
+# test: npm (install-tool npm)
 #--------------------------------------
 FROM build as teste
 
 SHELL [ "/bin/sh", "-c" ]
 
+USER root
 # don't update!!
 RUN install-tool npm 8.0.0
 
-RUN node --version
 RUN npm --version
 RUN npm --version | grep '8.0.0'
 
+USER 1000
+
+# don't update!!
+RUN install-tool npm 8.0.1
+
+RUN node --version
+RUN npm --version
+RUN npm --version | grep '8.0.1'
 
 #--------------------------------------
-# test: npm (root)
+# test: npm (npm i -g npm)
 #--------------------------------------
 FROM build as testf
 
-USER root
 SHELL [ "/bin/sh", "-c" ]
 
+USER root
 # don't update!!
 RUN install-tool npm 8.0.0
 
-RUN node --version
 RUN npm --version
 RUN npm --version | grep '8.0.0'
 
+USER 1000
+# don't update!!
+RUN install-tool npm 8.0.1
+RUN npm --version
+RUN npm --version | grep '8.0.1'
+
+
+#--------------------------------------
+# test: npm (install-npm npm)
+#--------------------------------------
+FROM build as testg
+
+SHELL [ "/bin/sh", "-c" ]
+
+USER root
+# don't update!!
+RUN install-npm npm 8.0.0
+
+RUN npm --version
+RUN npm --version | grep '8.0.0'
+
+USER 1000
+RUN npm --version
+RUN npm --version | grep '8.0.0'
+
+# openshift
+USER 1005
+RUN npm --version
+RUN npm --version | grep '8.0.0'
+RUN npm install
 
 #--------------------------------------
 # final
@@ -195,3 +227,4 @@ COPY --from=testc /.dummy /.dummy
 COPY --from=testd /.dummy /.dummy
 COPY --from=teste /.dummy /.dummy
 COPY --from=testf /.dummy /.dummy
+COPY --from=testg /.dummy /.dummy

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -4,7 +4,8 @@ FROM ${IMAGE} as build
 ARG APT_HTTP_PROXY
 
 # renovate: datasource=node
-RUN install-tool node v16.13.1
+# RUN install-tool node v16.13.1
+RUN install-tool node v14.18.1
 
 RUN touch /.dummy
 
@@ -47,21 +48,14 @@ FROM build as testb
 
 ARG APT_HTTP_PROXY
 
+RUN npm config ls
 RUN npm install -g yarn
 
 RUN set -ex; \
   [ "$(command -v yarn)" = "/home/${USER_NAME}/.npm-global/bin/yarn" ] && echo "works" || exit 1; \
   yarn --version;
 
-
 RUN set -ex; cd a; yarn
-
-ENV NPM_CONFIG_PREFIX=/tmp/.npm
-RUN npm install -g yarn
-
-RUN set -ex; \
-  [ "$(command -v yarn)" = "/tmp/.npm/bin/yarn" ] && echo "works" || exit 1; \
-  yarn --version;
 
 
 SHELL [ "/bin/sh", "-c" ]
@@ -105,7 +99,7 @@ RUN set -ex; cd a; pnpm i
 SHELL [ "/bin/sh", "-c" ]
 RUN set -ex; \
   pnpm --version \
-  [ "$(command -v pnpm)" = "/home/${USER_NAME}/bin/pnpm" ] && echo "works" || exit 1;
+  [ "$(command -v pnpm)" = "/home/user/bin/pnpm" ] && echo "works" || exit 1;
 
 #--------------------------------------
 # test: node 17
@@ -139,15 +133,6 @@ RUN set -ex; \
   [ "$(command -v yarn)" = "/home/${USER_NAME}/.npm-global/bin/yarn" ] && echo "works" || exit 1; \
   yarn --version;
 
-RUN mkdir -p /tmp/.npm/{bin,lib}
-ENV NPM_CONFIG_PREFIX=/tmp/.npm
-RUN npm install -g yarn
-
-RUN set -ex; \
-  [ "$(command -v yarn)" = "/tmp/.npm/bin/yarn" ] && echo "works" || exit 1; \
-  yarn --version;
-
-
 #--------------------------------------
 # test: npm (install-tool npm)
 #--------------------------------------
@@ -165,31 +150,29 @@ RUN npm --version | grep '8.0.0'
 USER 1000
 
 # don't update!!
-RUN install-tool npm 8.0.1
+RUN install-tool npm 7.24.2
 
 RUN node --version
 RUN npm --version
-RUN npm --version | grep '8.0.1'
+RUN npm --version | grep '7.24.2'
 
 #--------------------------------------
 # test: npm (npm i -g npm)
 #--------------------------------------
 FROM build as testf
 
-SHELL [ "/bin/sh", "-c" ]
-
 USER root
-# don't update!!
-RUN install-tool npm 8.0.0
+# don't update!! need force to overwrite symlink
+RUN npm i -gf npm@8.0.0
 
-RUN npm --version
-RUN npm --version | grep '8.0.0'
+RUN set -ex; command -v npm; npm --version
+RUN set -ex; npm --version | grep '8.0.0'
 
 USER 1000
 # don't update!!
-RUN install-tool npm 8.0.1
-RUN npm --version
-RUN npm --version | grep '8.0.1'
+RUN npm i -g npm@7.24.2
+RUN set -ex; command -v npm; npm --version
+RUN set -ex; npm --version | grep '7.24.2'
 
 
 #--------------------------------------
@@ -201,20 +184,23 @@ SHELL [ "/bin/sh", "-c" ]
 
 USER root
 # don't update!!
-RUN install-npm npm 8.0.0
+RUN set -ex; echo $PATH; install-npm npm 8.0.0
 
-RUN npm --version
-RUN npm --version | grep '8.0.0'
+RUN set -ex; command -v npm; npm --version
+RUN set -ex; npm --version | grep '8.0.0'
 
 USER 1000
-RUN npm --version
-RUN npm --version | grep '8.0.0'
+RUN set -ex; command -v npm; npm --version
+RUN set -ex; npm --version | grep '8.0.0'
+RUN chmod -R g+w .
 
 # openshift
 USER 1005
-RUN npm --version
-RUN npm --version | grep '8.0.0'
-RUN npm install
+# autoload bash env required
+SHELL [ "/bin/bash", "-c" ]
+RUN set -ex; command -v npm; npm --version
+RUN set -ex; npm --version | grep '8.0.0'
+RUN set -ex; cd a; npm install
 
 #--------------------------------------
 # final

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -47,7 +47,6 @@ FROM build as testb
 
 ARG APT_HTTP_PROXY
 
-RUN npm config ls
 RUN npm install -g yarn
 
 RUN set -ex; \

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -182,7 +182,7 @@ SHELL [ "/bin/sh", "-c" ]
 
 USER root
 # don't update!!
-RUN set -ex; echo $PATH; install-npm npm 8.0.0
+RUN set -ex; install-npm npm 8.0.0
 
 RUN set -ex; command -v npm; npm --version
 RUN set -ex; npm --version | grep '8.0.0'

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -4,8 +4,7 @@ FROM ${IMAGE} as build
 ARG APT_HTTP_PROXY
 
 # renovate: datasource=node
-# RUN install-tool node v16.13.1
-RUN install-tool node v14.18.1
+RUN install-tool node v16.13.1
 
 RUN touch /.dummy
 

--- a/test/node/test/a/package.json
+++ b/test/node/test/a/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "re2": " 1.16.0",
+    "re2": " 1.17.0",
     "semver": "7.3.2"
   }
 }

--- a/test/node/test/a/package.json
+++ b/test/node/test/a/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "re2": " 1.16.0",
     "semver": "7.3.2"
   }
 }


### PR DESCRIPTION
- ref #213 

`PATH` search order:

- `/home/<user>/.npm-global/bin` (user `npm install -g`)
- `/home/<user>/bin` (user install)
- `/usr/local/bin` (root install)

global prefix is now `/usr/local`, so `install-npm npm` overwrites `/usr/local/bin`