### PR TITLE
fix: properly test for installed git-lfs

### DIFF
--- a/src/usr/local/buildpack/tools/git-lfs.sh
+++ b/src/usr/local/buildpack/tools/git-lfs.sh
@@ -16,9 +16,9 @@ if [[ -x "$(command -v git-lfs)" ]]; then
 fi
 
 ARCH=linux-amd64
-LFS_FILE="git-lfs-${ARCH}-${TOOL_VERSION}.tar.gz"
+LFS_FILE="git-lfs-${ARCH}-v${TOOL_VERSION}.tar.gz"
 
-curl -sSfLo git-lfs.tgz https://github.com/git-lfs/git-lfs/releases/download/${TOOL_VERSION}/${LFS_FILE}
+curl -sSfLo git-lfs.tgz https://github.com/git-lfs/git-lfs/releases/download/v${TOOL_VERSION}/${LFS_FILE}
 tar xzvf git-lfs.tgz -C /usr/local/bin git-lfs
 rm git-lfs.tgz
 

--- a/src/usr/local/buildpack/tools/git-lfs.sh
+++ b/src/usr/local/buildpack/tools/git-lfs.sh
@@ -10,7 +10,7 @@ if [[ ! "${MAJOR}" || ! "${MINOR}" || ! "${PATCH}" ]]; then
   exit 1
 fi
 
-if ! [ "$(command -v git-lfs)" ]; then
+if [[ -x "$(command -v git-lfs)" ]]; then
   echo "Skipping, already installed"
   exit 0
 fi

--- a/test/Dockerfile.bionic
+++ b/test/Dockerfile.bionic
@@ -94,6 +94,7 @@ RUN install-tool terraform 1.1.3
 
 # renovate: datasource=github-releases lookupName=git-lfs/git-lfs
 RUN install-tool git-lfs v3.0.2
+RUN git lfs version
 
 # renovate: datasource=github-releases lookupName=jsonnet-bundler/jsonnet-bundler
 RUN install-tool jb v0.4.0


### PR DESCRIPTION
The test before claimed that `git-lfs` is already installed, even if it was not.