### PR TITLE
feat: add shellcheck pre-commit command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 . "$(dirname "$0")/_/husky.sh"
 
-# Woraround for Visual Studio MinGit
-export PATH="$(readlink -f "$(dirname "$0")/../node_modules/.bin"):$PATH"
+yarn pretty-quick --staged
 
-pretty-quick --staged
+if ! command -v shellcheck > /dev/null 2>&1
+then
+    echo "shellcheck could not be found"
+    exit
+fi
+
+changed_files=$(git diff --diff-filter=M --cached --name-only | { grep -E '^src' || true; })
+if [ ${#changed_files} -gt 0 ]; then
+    shellcheck ${changed_files[@]}
+fi


### PR DESCRIPTION
@viceice Please review.

I took some lines from the Renovate `pre-commit` hook: https://github.com/renovatebot/renovate/blob/main/.husky/pre-commit

`#!/bin/bash` was needed for the array of files.