### PR TITLE
feat: add new tool contract

### DIFF
--- a/src/usr/local/bin/install-tool
+++ b/src/usr/local/bin/install-tool
@@ -40,9 +40,8 @@ if [[ -f "$V2_TOOL" ]]; then
   else
       echo "Tool ${TOOL_NAME} v${TOOL_VERSION} is already linked"
   fi
-
 elif [[ -f "$TOOL" ]]; then
-    echo "Installing legacy tool ${TOOL_NAME} v${TOOL_VERSION}"
+  echo "Installing legacy tool ${TOOL_NAME} v${TOOL_VERSION}"
   # shellcheck source=/dev/null
   . "$TOOL"
 else

--- a/src/usr/local/bin/install-tool
+++ b/src/usr/local/bin/install-tool
@@ -9,21 +9,46 @@ require_distro
 require_user
 require_tool "$@"
 
-TOOL="/usr/local/buildpack/tools/${TOOL_NAME}.sh"
-if [[ ! -f "$TOOL" ]]; then
-  echo "No tool defined - skipping: ${TOOL_NAME}" >&2
-  exit 1;
-fi
-
 if [[ $(ignore_tool) -eq 1 ]]; then
   echo "Tool ignored - skipping: ${TOOL_NAME}"
   exit 0;
 fi
 
+TOOL="/usr/local/buildpack/tools/${TOOL_NAME}.sh"
+V2_TOOL="/usr/local/buildpack/tools/v2/${TOOL_NAME}.sh"
 
-echo "Installing tool ${TOOL_NAME} v${TOOL_VERSION}"
-# shellcheck source=/dev/null
-. "$TOOL"
+if [[ -f "$V2_TOOL" ]]; then
+  # It is not a legacy tool, so call the new methods
+
+  # shellcheck source=/dev/null
+  . /usr/local/buildpack/utils/defaults.sh
+  # shellcheck source=/dev/null
+  . "$TOOL"
+
+  if ! check_tool_installed; then
+    echo "Installing tool ${TOOL_NAME} v${TOOL_VERSION}"
+    check_tool_requirements
+    install_tool
+  else
+    echo "Tool ${TOOL_NAME} v${TOOL_VERSION} is already installed"
+  fi
+
+  if [[ "${TOOL_VERSION}" != "$(get_tool_version)" ]]; then
+    # link the tool
+    echo "Linking tool ${TOOL_NAME} v${TOOL_VERSION}"
+    link_tool
+  else
+      echo "Tool ${TOOL_NAME} v${TOOL_VERSION} is already linked"
+  fi
+
+elif [[ -f "$TOOL" ]]; then
+    echo "Installing legacy tool ${TOOL_NAME} v${TOOL_VERSION}"
+  # shellcheck source=/dev/null
+  . "$TOOL"
+else
+  echo "No tool defined - skipping: ${TOOL_NAME}" >&2
+  exit 1;
+fi
 
 # cleanup
 if [[ $EUID -eq 0 ]]; then

--- a/src/usr/local/buildpack/utils/defaults.sh
+++ b/src/usr/local/buildpack/utils/defaults.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This file contains all functions a tool must implement to be properly supported
+# The buildpack scripts rely on the functions to decide if a tool needs to be handled in a special way
+# This defaults are loaded before any tool file so not overwriting the function will
+# result in the install process being aborted
+
+# Is used to check if all requirements are met to install the tool
+function check_tool_requirements () {
+  echo "'check_tool_requirements' not defined for tool ${TOOL_NAME}"
+  exit 1
+}
+
+# Is used to check if the tool has already been installed in the given version
+function check_tool_installed () {
+  echo "'check_tool_installed' not defined for tool ${TOOL_NAME}"
+  exit 1
+}
+
+# Installs the tool with the given version
+function install_tool () {
+  echo "'install_tool' not defined for tool ${TOOL_NAME}"
+  exit 1
+}
+
+# Links the tools installation to the global bin folders
+function link_tool () {
+  echo "'link_tool' not defined for tool ${TOOL_NAME}"
+  exit 1
+}
+
+# Installs needed packages to make the tool runtime installable
+function prepare_tool() {
+  echo "'prepare_tool' not defined for tool ${TOOL_NAME}"
+  exit 0
+}


### PR DESCRIPTION
This adds the new tools contract only.

When a tool is located in `/usr/local/buildpack/tools/v2/<TOOL>.sh` then it is considered a new tool (in terms of contract) and will be installed with the methods defined in the `defaults.sh`.

When the tool is available in the old and new path, then the new path is preferred.