### PR TITLE
fix: use valid path for linking

### DIFF
--- a/src/usr/local/buildpack/utils/linking.sh
+++ b/src/usr/local/buildpack/utils/linking.sh
@@ -3,8 +3,8 @@
 # use this if custom env is required, creates a shell wrapper to /usr/local/bin or /home/<user>/bin
 function shell_wrapper () {
   local install_dir
-  local FILE="${install_dir}/bin/${1}"
   install_dir=$(get_install_dir)
+  local FILE="${install_dir}/bin/${1}"
   check_command "$1"
   cat > "$FILE" <<- EOM
 #!/bin/bash


### PR DESCRIPTION
@viceice This somehow got introduced while I did the utils splitting or during our shellcheck changes.

This should fix the linking against `/bin/<tool>`