### PR TITLE
refactor: move setup for env files to helper file

### DIFF
--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -29,39 +29,7 @@ if [[ "${BASH_ENV}" != "${ENV_FILE}" ]]; then
   exit 1;
 fi
 
-
-# env helper, loads tool specific env
-cat >> "$ENV_FILE" <<- EOM
-export BUILDPACK=1 USER_NAME="${USER_NAME}" USER_ID="${USER_ID}" USER_HOME="/home/${USER_NAME}"
-
-# openshift override unknown user home
-if [ "\${EUID}" != 0 ]; then
-  export HOME="\${USER_HOME}"
-fi
-
-if [ -d /usr/local/env.d ]; then
-  for i in /usr/local/env.d/*.sh; do
-    if [ -r \$i ]; then
-      . \$i
-    fi
-  done
-  unset i
-fi
-if [ -d /home/"${USER_NAME}"/env.d ]; then
-  for i in /home/"${USER_NAME}"/env.d/*.sh; do
-    if [ -r \$i ]; then
-      . \$i
-    fi
-  done
-  unset i
-fi
-EOM
-
-cat >> /etc/bash.bashrc <<- EOM
-if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
-  . $ENV_FILE
-fi
-EOM
+setup_env_files
 
 echo "APT::Install-Recommends \"false\";" | tee -a /etc/apt/apt.conf.d/buildpack.conf
 echo "APT::Get::Install-Suggests \"false\";" | tee -a /etc/apt/apt.conf.d/buildpack.conf

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -12,8 +12,6 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 # shellcheck source=/dev/null
 . "${DIR}/utils/linking.sh"
 
-export ENV_FILE=/usr/local/etc/env
-
 check_debug() {
   local bool="${BUILDPACK_DEBUG:-false}"
   # comparison is performed without regard to the case of alphabetic characters


### PR DESCRIPTION
Moves the setup for the env file into the `environment.sh` helper file.
This is needed to setup proper testing with bats