### PR TITLE
chore: add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM containerbase/node:14.19.0@sha256:846824bb8ecb9029890d937248b7af17710d1670966269c181314c8f440e8e6d
+
+# renovate: datasource=npm
+RUN install-tool yarn 1.22.17
+
+USER root
+RUN install-apt shellcheck
+USER 1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "buildpack",
+  "dockerFile": "Dockerfile",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
+  "postCreateCommand": "yarn install"
+}


### PR DESCRIPTION
@viceice This adds a devcontainer to the buildpack repo.

I orientated myself on the Renovate devcontainer and added shellcheck.
Not sure if the user switch can be done more elegantly.