### PR TITLE
refactor: add version helper with tests

### DIFF
--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -20,6 +20,8 @@ export USER_UMASK=770
 . "${DIR}/utils/filesystem.sh"
 # shellcheck source=/dev/null
 . "${DIR}/utils/linking.sh"
+# shellcheck source=/dev/null
+. "${DIR}/utils/version.sh"
 
 check_debug() {
   local bool="${BUILDPACK_DEBUG:-false}"

--- a/src/usr/local/buildpack/utils/environment.sh
+++ b/src/usr/local/buildpack/utils/environment.sh
@@ -72,12 +72,6 @@ function export_tool_path () {
   fi
 }
 
-function get_tool_version_env () {
-  local tool=${1//-/_}
-  tool=${tool^^}_VERSION
-  echo "${tool}"
-}
-
 function setup_env_files () {
   # env helper, loads tool specific env
   local install_dir

--- a/src/usr/local/buildpack/utils/version.sh
+++ b/src/usr/local/buildpack/utils/version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Will set the version of the given tool to the given version in the versions folder
+function set_tool_version () {
+  local tool=${1:-$TOOL_NAME}
+  local version=${2:-$TOOL_VERSION}
+
+  check tool true
+  check version true
+
+  local version_path
+  version_path=$(get_version_path)
+
+  echo "${version}" > "${version_path}/${tool}"
+  chmod 770 "${version_path}/${tool}"
+}
+
+# Gets the version of the tool behind $TOOL_NAME or the first argument
+# if it is set, empty otherwise
+function get_tool_version () {
+  local version_path
+  local tool=${1:-$TOOL_NAME}
+  check tool
+
+  version_path=$(get_version_path)
+
+  cat "${version_path}/${tool}" 2>&-
+}
+
+# Gets the version env var for the given tool
+# e.g
+#   get_tool_version_env foo-bar
+# returns
+#   FOO_BAR_VERSION
+function get_tool_version_env () {
+  local tool=${1//-/_}
+  check tool true
+
+  tool=${tool^^}_VERSION
+  echo "${tool}"
+}

--- a/src/usr/local/buildpack/utils/version.sh
+++ b/src/usr/local/buildpack/utils/version.sh
@@ -11,8 +11,10 @@ function set_tool_version () {
   local version_path
   version_path=$(get_version_path)
 
-  echo "${version}" > "${version_path}/${tool}"
-  chmod 770 "${version_path}/${tool}"
+  # set umask for subshell and enter version
+  # will only affect if we write the file initially
+  # umask 117 -> chmod 660
+  (umask 117 && echo "${version}" > "${version_path}/${tool}")
 }
 
 # Gets the version of the tool behind $TOOL_NAME or the first argument

--- a/test/bash/version.bats
+++ b/test/bash/version.bats
@@ -26,7 +26,8 @@ teardown() {
 
 @test "set and get versions" {
 
-  setup_directories
+  run setup_directories
+  assert_success
 
   run set_tool_version
   assert_failure
@@ -80,6 +81,34 @@ teardown() {
   run get_tool_version
   assert_success
   assert_output "1.1.1"
+}
+
+@test "can set version with different umask" {
+  local version_path=$(get_version_path)
+
+  run setup_directories
+  assert_success
+
+  touch "${version_path}/foo"
+  chmod 777 "${version_path}/foo"
+
+  run set_tool_version foo 1.2.3
+  assert_success
+
+  run get_tool_version foo
+  assert_success
+  assert_output "1.2.3"
+
+  assert [ $(stat --format '%a' "${version_path}/foo") -eq 777 ]
+
+  run set_tool_version bar 1.2.4
+  assert_success
+
+  run get_tool_version bar
+  assert_success
+  assert_output "1.2.4"
+
+  assert [ $(stat --format '%a' "${version_path}/bar") -eq 660 ]
 }
 
 @test "get_tool_version_env" {

--- a/test/bash/version.bats
+++ b/test/bash/version.bats
@@ -1,0 +1,104 @@
+
+setup() {
+  load '../../node_modules/bats-support/load'
+  load '../../node_modules/bats-assert/load'
+
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+    TEST_ROOT_DIR=$(mktemp -u)
+
+    load "$TEST_DIR/../../src/usr/local/buildpack/util.sh"
+
+    # load test overwrites
+    load "$TEST_DIR/util.sh"
+
+    # set directories for test
+    ROOT_DIR="${TEST_ROOT_DIR}/root"
+    USER_HOME="${TEST_ROOT_DIR}/user"
+    ENV_FILE="${TEST_ROOT_DIR}/env"
+
+    # set default test user
+    TEST_ROOT_USER=1000
+}
+
+teardown() {
+  rm -rf "${TEST_ROOT_DIR}"
+}
+
+@test "set and get versions" {
+
+  setup_directories
+
+  run set_tool_version
+  assert_failure
+
+  TOOL_NAME=foo TOOL_VERSION= \
+  run set_tool_version
+  assert_failure
+
+  TOOL_NAME= TOOL_VERSION= \
+  run set_tool_version
+  assert_failure
+
+  run set_tool_version foo
+  assert_failure
+
+  run set_tool_version "" 1.2.3
+  assert_failure
+
+  TOOL_NAME=foo TOOL_VERSION=1.2.3 \
+  run set_tool_version
+  assert_success
+
+  TOOL_NAME=foo TOOL_VERSION=1.2.3 \
+  run get_tool_version
+  assert_success
+  assert_output "1.2.3"
+
+  TOOL_NAME=foo TOOL_VERSION=1.2.4 \
+  run set_tool_version foobar
+  assert_success
+
+  TOOL_NAME=foo TOOL_VERSION=1.2.4 \
+  run get_tool_version foobar
+  assert_success
+  assert_output "1.2.4"
+
+  TOOL_NAME=foo TOOL_VERSION=1.2.4 \
+  run set_tool_version foobar1 1.2.5
+  assert_success
+
+  TOOL_NAME=foo TOOL_VERSION=1.2.4 \
+  run get_tool_version foobar1
+  assert_success
+  assert_output "1.2.5"
+
+  TOOL_NAME=bar TOOL_VERSION=1.2.4 \
+  run set_tool_version "" 1.1.1
+  assert_success
+
+  TOOL_NAME=bar TOOL_VERSION=1.2.4 \
+  run get_tool_version
+  assert_success
+  assert_output "1.1.1"
+}
+
+@test "get_tool_version_env" {
+
+  run get_tool_version_env
+  assert_failure
+
+  run get_tool_version_env ""
+  assert_failure
+
+  run get_tool_version_env foo-bar
+  assert_success
+  assert_output "FOO_BAR_VERSION"
+
+  run get_tool_version_env foo
+  assert_success
+  assert_output "FOO_VERSION"
+
+  run get_tool_version_env foo---bar
+  assert_success
+  assert_output "FOO___BAR_VERSION"
+}


### PR DESCRIPTION
This adds support to set versions for the tools and to query them
This is useful to detect if we need to link the tools again and can possibly help with further Renovate use cases.