### PR TITLE
fix: do not overwrite cache env vars

### DIFF
--- a/src/usr/local/buildpack/utils/constants.sh
+++ b/src/usr/local/buildpack/utils/constants.sh
@@ -14,11 +14,11 @@ export ROOT_UMASK=750
 # defines the umask fo folders created by the user
 export USER_UMASK=770
 # defines the cache folder for downloaded tools, if empty no cache will be used
-export BUILDPACK_CACHE_DIR=
+export BUILDPACK_CACHE_DIR=${BUILDPACK_CACHE_DIR}
 # defines the max amount of filled space (in percent from 0-100) that is allowed
 # before the installation tries to free space by cleaning the cache folder
 # If empty, then cache cleanup is disabled
-export BUILDPACK_MAX_ALLOCATED_DISK=
+export BUILDPACK_MAX_ALLOCATED_DISK=${BUILDPACK_MAX_ALLOCATED_DISK}
 # defines the temp directory that will be used when the cache is not active
 # it is used for all downloads and will be cleaned up after each install
 export TEMP_DIR=/tmp


### PR DESCRIPTION
This fixes that the cache vars are not overridden  when they are set in the image already.