### PR TITLE
fix: do not abort when no version is available

### DIFF
--- a/src/usr/local/buildpack/utils/version.sh
+++ b/src/usr/local/buildpack/utils/version.sh
@@ -26,7 +26,7 @@ function get_tool_version () {
 
   version_path=$(get_version_path)
 
-  cat "${version_path}/${tool}" 2>&-
+  cat "${version_path}/${tool}" 2>&- || true
 }
 
 # Gets the version env var for the given tool


### PR DESCRIPTION
When used to install a tool in version 2, the installation would abort of no version is set.
Now it will always return an empty string