### PR TITLE
fix: do not abort if cache var is empty

### DIFF
--- a/src/usr/local/buildpack/utils/cache.sh
+++ b/src/usr/local/buildpack/utils/cache.sh
@@ -47,7 +47,11 @@ function download_file () {
 # If BUILDPACK_CACHE_MAX_ALLOCATED_DISK is not set then the cache will be cleaned
 function cleanup_cache () {
   local single_file=${1:false}
-  check BUILDPACK_CACHE_DIR true
+
+  if [ -z "${BUILDPACK_CACHE_DIR}" ]; then
+    # BUILD_CACHE_DIR is empty
+    exit 0
+  fi
 
   local max_fill_level=${BUILDPACK_CACHE_MAX_ALLOCATED_DISK:-100}
 

--- a/test/bash/cache.bats
+++ b/test/bash/cache.bats
@@ -86,6 +86,9 @@ teardown() {
     echo $TEST_FILL_LEVEL
   }
 
+  run cleanup_cache
+  assert_success
+
   # create cache dir
   BUILDPACK_CACHE_DIR="${TEST_ROOT_DIR}/cache"
   mkdir -p "${BUILDPACK_CACHE_DIR}/b"
@@ -100,12 +103,12 @@ teardown() {
   BUILDPACK_CACHE_DIR= \
   BUILDPACK_CACHE_MAX_ALLOCATED_DISK= \
   run cleanup_cache
-  assert_failure
+  assert_success
 
   BUILDPACK_CACHE_DIR= \
   BUILDPACK_CACHE_MAX_ALLOCATED_DISK=20 \
   run cleanup_cache
-  assert_failure
+  assert_success
 
   BUILDPACK_CACHE_MAX_ALLOCATED_DISK= \
   run cleanup_cache


### PR DESCRIPTION
When we call `cleanup_cache` it should silently return instead of abort.