### PR TITLE
fix: use /usr/local/bin as bin path

### DIFF
--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -85,7 +85,6 @@ function prepare_v2_tools () {
   . /usr/local/buildpack/utils/v2/overrides.sh
 
   setup_directories
-  export_path "$(get_bin_path)"
 }
 prepare_v2_tools
 

--- a/src/usr/local/buildpack/utils/constants.sh
+++ b/src/usr/local/buildpack/utils/constants.sh
@@ -6,7 +6,7 @@ export ENV_FILE=/usr/local/etc/env
 export BASH_RC=/etc/bash.bashrc
 # defines the root directory where tools will be installed
 export ROOT_DIR=/usr/local
-# defines the root directory where tools will be installed
+# defines the directory where symlinks to tools will be installed
 export BIN_DIR=/usr/local/bin
 # defines the directory where user tools will be installed
 # shellcheck disable=SC2153

--- a/src/usr/local/buildpack/utils/constants.sh
+++ b/src/usr/local/buildpack/utils/constants.sh
@@ -6,6 +6,8 @@ export ENV_FILE=/usr/local/etc/env
 export BASH_RC=/etc/bash.bashrc
 # defines the root directory where tools will be installed
 export ROOT_DIR=/usr/local
+# defines the root directory where tools will be installed
+export BIN_DIR=/usr/local/bin
 # defines the directory where user tools will be installed
 # shellcheck disable=SC2153
 export USER_HOME="/home/${USER_NAME}"

--- a/src/usr/local/buildpack/utils/filesystem.sh
+++ b/src/usr/local/buildpack/utils/filesystem.sh
@@ -54,7 +54,7 @@ function setup_directories () {
   mkdir -p -m 770 "$(get_version_path)"
   # contains the wrapper and symlinks for the tools
   # shellcheck disable=SC2174
-  mkdir -p -m 755 "$(get_bin_path)"
+  mkdir -p -m 775 "$(get_bin_path)"
 }
 
 # Creates the given folder path with root and user umask depending on the caller

--- a/src/usr/local/buildpack/utils/filesystem.sh
+++ b/src/usr/local/buildpack/utils/filesystem.sh
@@ -55,6 +55,12 @@ function setup_directories () {
   # contains the wrapper and symlinks for the tools
   # shellcheck disable=SC2174
   mkdir -p -m 775 "$(get_bin_path)"
+
+  # if the bin path exists and does not have 775, force it
+  if [ "$(stat --format '%a' "$(get_bin_path)")" -ne 775 ]; then
+    echo "Forcing 775 on '$(get_bin_path)' ..."
+    chmod 775 "$(get_bin_path)"
+  fi
 }
 
 # Creates the given folder path with root and user umask depending on the caller

--- a/src/usr/local/buildpack/utils/filesystem.sh
+++ b/src/usr/local/buildpack/utils/filesystem.sh
@@ -44,13 +44,17 @@ function setup_directories () {
 
   mkdir -p "${install_dir}"
   # contains the installed tools
-  mkdir -m 770 "$(get_tools_path)"
+  # shellcheck disable=SC2174
+  mkdir -p -m 770 "$(get_tools_path)"
   # contains env for the installed tools
-  mkdir -m 770 "$(get_env_path)"
+  # shellcheck disable=SC2174
+  mkdir -p -m 770 "$(get_env_path)"
   # contains the latest version of the tools
-  mkdir -m 770 "$(get_version_path)"
+  # shellcheck disable=SC2174
+  mkdir -p -m 770 "$(get_version_path)"
   # contains the wrapper and symlinks for the tools
-  mkdir -m 770 "$(get_bin_path)"
+  # shellcheck disable=SC2174
+  mkdir -p -m 755 "$(get_bin_path)"
 }
 
 # Creates the given folder path with root and user umask depending on the caller
@@ -78,9 +82,7 @@ function create_folder () {
 
 # Gets the path to the bin folder
 function get_bin_path () {
-  local install_dir
-  install_dir=$(get_install_dir)
-  echo "${install_dir}/bin"
+  echo "${ROOT_DIR}/bin"
 }
 
 # Gets the path to the versions folder

--- a/src/usr/local/buildpack/utils/filesystem.sh
+++ b/src/usr/local/buildpack/utils/filesystem.sh
@@ -88,7 +88,7 @@ function create_folder () {
 
 # Gets the path to the bin folder
 function get_bin_path () {
-  echo "${ROOT_DIR}/bin"
+  echo "${BIN_DIR}"
 }
 
 # Gets the path to the versions folder

--- a/test/bash/cache.bats
+++ b/test/bash/cache.bats
@@ -13,6 +13,7 @@ setup() {
 
     # set directories for test
     ROOT_DIR="${TEST_ROOT_DIR}/root"
+    BIN_DIR="${TEST_ROOT_DIR}/bin"
     USER_HOME="${TEST_ROOT_DIR}/user"
     ENV_FILE="${TEST_ROOT_DIR}/env"
 

--- a/test/bash/environment.bats
+++ b/test/bash/environment.bats
@@ -12,6 +12,7 @@ setup() {
 
   # set directories for test
   ROOT_DIR="${TEST_ROOT_DIR}/root"
+  BIN_DIR="${TEST_ROOT_DIR}/bin"
   USER_HOME="${TEST_ROOT_DIR}/user"
   ENV_FILE="${TEST_ROOT_DIR}/env"
   BASH_RC="${TEST_ROOT_DIR}/bash.bashrc"

--- a/test/bash/filesystem.bats
+++ b/test/bash/filesystem.bats
@@ -128,7 +128,7 @@ teardown() {
   assert [ -d "${install_dir}/versions" ]
   assert [ $(stat --format '%a' "${install_dir}/versions") -eq 770 ]
   assert [ -d "${ROOT_DIR}/bin" ]
-  assert [ $(stat --format '%a' "${ROOT_DIR}/bin") -eq 755 ]
+  assert [ $(stat --format '%a' "${ROOT_DIR}/bin") -eq 775 ]
   assert [ -d "${install_dir}/env.d" ]
   assert [ $(stat --format '%a' "${install_dir}/env.d") -eq 770 ]
 }

--- a/test/bash/filesystem.bats
+++ b/test/bash/filesystem.bats
@@ -12,6 +12,7 @@ setup() {
 
     # set directories for test
     ROOT_DIR="${TEST_ROOT_DIR}/root"
+    BIN_DIR="${TEST_ROOT_DIR}/bin"
     USER_HOME="${TEST_ROOT_DIR}/user"
 
     # set default test user
@@ -127,8 +128,8 @@ teardown() {
   assert [ $(stat --format '%a' "${install_dir}/tools") -eq 770 ]
   assert [ -d "${install_dir}/versions" ]
   assert [ $(stat --format '%a' "${install_dir}/versions") -eq 770 ]
-  assert [ -d "${ROOT_DIR}/bin" ]
-  assert [ $(stat --format '%a' "${ROOT_DIR}/bin") -eq 775 ]
+  assert [ -d "${BIN_DIR}" ]
+  assert [ $(stat --format '%a' "${BIN_DIR}") -eq 775 ]
   assert [ -d "${install_dir}/env.d" ]
   assert [ $(stat --format '%a' "${install_dir}/env.d") -eq 770 ]
 }

--- a/test/bash/filesystem.bats
+++ b/test/bash/filesystem.bats
@@ -127,8 +127,8 @@ teardown() {
   assert [ $(stat --format '%a' "${install_dir}/tools") -eq 770 ]
   assert [ -d "${install_dir}/versions" ]
   assert [ $(stat --format '%a' "${install_dir}/versions") -eq 770 ]
-  assert [ -d "${install_dir}/bin" ]
-  assert [ $(stat --format '%a' "${install_dir}/bin") -eq 770 ]
+  assert [ -d "${ROOT_DIR}/bin" ]
+  assert [ $(stat --format '%a' "${ROOT_DIR}/bin") -eq 755 ]
   assert [ -d "${install_dir}/env.d" ]
   assert [ $(stat --format '%a' "${install_dir}/env.d") -eq 770 ]
 }

--- a/test/bash/linking.bats
+++ b/test/bash/linking.bats
@@ -13,6 +13,7 @@ setup() {
 
     # set directories for test
     ROOT_DIR="${TEST_ROOT_DIR}/root"
+    BIN_DIR="${TEST_ROOT_DIR}/bin"
     USER_HOME="${TEST_ROOT_DIR}/user"
     ENV_FILE="${TEST_ROOT_DIR}/env"
 

--- a/test/bash/util.bats
+++ b/test/bash/util.bats
@@ -8,6 +8,12 @@ setup() {
   # Not used yet, but will be later
   TEST_ROOT_DIR=$(mktemp -u)
 
+  # set directories for test
+  ROOT_DIR="${TEST_ROOT_DIR}/root"
+  BIN_DIR="${TEST_ROOT_DIR}/bin"
+  USER_HOME="${TEST_ROOT_DIR}/user"
+  ENV_FILE="${TEST_ROOT_DIR}/env"
+
   load "$TEST_DIR/../../src/usr/local/buildpack/util.sh"
 }
 

--- a/test/bash/v2/filesystem.bats
+++ b/test/bash/v2/filesystem.bats
@@ -15,6 +15,7 @@ setup() {
 
   # set directories for test
   ROOT_DIR="${TEST_ROOT_DIR}/root"
+  BIN_DIR="${TEST_ROOT_DIR}/bin"
 
   # set default test user
   TEST_ROOT_USER=1000

--- a/test/bash/version.bats
+++ b/test/bash/version.bats
@@ -13,6 +13,7 @@ setup() {
 
     # set directories for test
     ROOT_DIR="${TEST_ROOT_DIR}/root"
+    BIN_DIR="${TEST_ROOT_DIR}/bin"
     USER_HOME="${TEST_ROOT_DIR}/user"
     ENV_FILE="${TEST_ROOT_DIR}/env"
 

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -188,7 +188,7 @@ FROM build as testi
 
 ARG APT_HTTP_PROXY
 
-RUN test [ $(stat --format '%a' "/usr/local/bin") -eq 775 ]
+RUN [ $(stat --format '%a' "/usr/local/bin") -eq 775 ]
 
 #--------------------------------------
 # final

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -182,6 +182,15 @@ RUN install-tool node v16.14.0
 RUN install-tool docker v20.10.12
 
 #--------------------------------------
+# test: bin path has 775
+#--------------------------------------
+FROM build as testi
+
+ARG APT_HTTP_PROXY
+
+RUN test [ $(stat --format '%a' "/usr/local/bin") -eq 775 ]
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM ${IMAGE}
@@ -194,3 +203,4 @@ COPY --from=teste /.dummy /.dummy
 COPY --from=testf /.dummy /.dummy
 COPY --from=testg /.dummy /.dummy
 COPY --from=testh /.dummy /.dummy
+COPY --from=testi /.dummy /.dummy


### PR DESCRIPTION
Changes the bin path from `/opt/buildpack/bin` to `/usr/local/bin` as discussed in #300 