### PR TITLE
fix: missing root group for user

### DIFF
--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -39,7 +39,7 @@ echo "APT::Get::Install-Suggests \"false\";" | tee -a /etc/apt/apt.conf.d/buildp
 # Set up user and home directory with access to users in the root group (0)
 # https://docs.openshift.com/container-platform/3.6/creating_images/guidelines.html#use-uid
 groupadd --gid ${USER_ID} ${USER_NAME};
-useradd --uid ${USER_ID} --gid 0 --groups ${USER_NAME} --shell /bin/bash --create-home ${USER_NAME}
+useradd --uid ${USER_ID} --gid 0 --groups "${USER_NAME},root" --shell /bin/bash --create-home ${USER_NAME}
 
 # create env helper paths
 mkdir /usr/local/env.d

--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -39,7 +39,7 @@ echo "APT::Get::Install-Suggests \"false\";" | tee -a /etc/apt/apt.conf.d/buildp
 # Set up user and home directory with access to users in the root group (0)
 # https://docs.openshift.com/container-platform/3.6/creating_images/guidelines.html#use-uid
 groupadd --gid ${USER_ID} ${USER_NAME};
-useradd --uid ${USER_ID} --gid 0 --groups "${USER_NAME},root" --shell /bin/bash --create-home ${USER_NAME}
+useradd --uid ${USER_ID} --gid 0 --groups "${USER_NAME}" --shell /bin/bash --create-home ${USER_NAME}
 
 # create env helper paths
 mkdir /usr/local/env.d

--- a/src/usr/local/buildpack/utils/filesystem.sh
+++ b/src/usr/local/buildpack/utils/filesystem.sh
@@ -45,13 +45,13 @@ function setup_directories () {
   mkdir -p "${install_dir}"
   # contains the installed tools
   # shellcheck disable=SC2174
-  mkdir -p -m 770 "$(get_tools_path)"
+  mkdir -p -m 775 "$(get_tools_path)"
   # contains env for the installed tools
   # shellcheck disable=SC2174
-  mkdir -p -m 770 "$(get_env_path)"
+  mkdir -p -m 775 "$(get_env_path)"
   # contains the latest version of the tools
   # shellcheck disable=SC2174
-  mkdir -p -m 770 "$(get_version_path)"
+  mkdir -p -m 775 "$(get_version_path)"
   # contains the wrapper and symlinks for the tools
   # shellcheck disable=SC2174
   mkdir -p -m 775 "$(get_bin_path)"

--- a/test/helm/Dockerfile
+++ b/test/helm/Dockerfile
@@ -6,8 +6,6 @@ RUN touch /.dummy
 # renovate: datasource=github-releases lookupName=helm/helm
 ARG HELM_VERSION=3.8.0
 
-USER 1000
-
 #--------------------------------------
 # install helm as root
 #--------------------------------------
@@ -49,6 +47,8 @@ RUN helm version | grep "${HELM_VERSION}"
 #--------------------------------------
 FROM build as testc
 
+USER 1000
+
 RUN install-tool helm "v${HELM_VERSION}"
 
 USER 1111
@@ -67,6 +67,23 @@ SHELL [ "/bin/sh", "-c" ]
 RUN helm version | grep "3.7.0"
 
 #--------------------------------------
+# install helm user 1000:1000
+#--------------------------------------
+FROM build as testd
+
+USER 1000:1000
+
+RUN install-tool helm "v${HELM_VERSION}"
+
+RUN set -ex; \
+  helm repo add stable https://charts.helm.sh/stable; \
+  helm repo update
+
+SHELL [ "/bin/sh", "-c" ]
+
+RUN helm version | grep "${HELM_VERSION}"
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM build
@@ -74,3 +91,4 @@ FROM build
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
+COPY --from=testd /.dummy /.dummy

--- a/test/helm/Dockerfile
+++ b/test/helm/Dockerfile
@@ -15,6 +15,8 @@ RUN install-tool helm "v${HELM_VERSION}"
 
 RUN set -ex; helm version
 
+USER 1000:1000
+
 RUN set -ex; \
   helm repo add stable https://charts.helm.sh/stable; \
   helm repo update

--- a/test/helm/Dockerfile
+++ b/test/helm/Dockerfile
@@ -68,22 +68,6 @@ SHELL [ "/bin/sh", "-c" ]
 
 RUN helm version | grep "3.7.0"
 
-#--------------------------------------
-# install helm user 1000:1000
-#--------------------------------------
-FROM build as testd
-
-USER 1000:1000
-
-RUN install-tool helm "v${HELM_VERSION}"
-
-RUN set -ex; \
-  helm repo add stable https://charts.helm.sh/stable; \
-  helm repo update
-
-SHELL [ "/bin/sh", "-c" ]
-
-RUN helm version | grep "${HELM_VERSION}"
 
 #--------------------------------------
 # final
@@ -93,4 +77,3 @@ FROM build
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
-COPY --from=testd /.dummy /.dummy


### PR DESCRIPTION
Add buildpack user explicit to root group.

- fixes #334