### PR TITLE
fix: shell wrapper has 775 permissions for overwrites

### DIFF
--- a/src/usr/local/buildpack/utils/linking.sh
+++ b/src/usr/local/buildpack/utils/linking.sh
@@ -3,7 +3,7 @@
 # use this if custom env is required, creates a shell wrapper to /usr/local/bin
 function shell_wrapper () {
   local FILE
-  FILE="$(get_bin_path)/bin/${1}"
+  FILE="$(get_bin_path)/${1}"
   check_command "$1"
   cat > "$FILE" <<- EOM
 #!/bin/bash
@@ -20,7 +20,8 @@ fi
 
 ${1} "\$@"
 EOM
-  chmod +x "$FILE"
+  # make it writable for the owner and the group
+  chmod 775 "$FILE"
 }
 
 # use this for simple symlink to /usr/local/bin

--- a/test/bash/linking.bats
+++ b/test/bash/linking.bats
@@ -62,6 +62,10 @@ teardown() {
 
 @test "shell_wrapper" {
 
+  mkdir -p "${USER_HOME}/bin"
+  echo "#!/bin/bash\n\necho 'foobar'" > "${USER_HOME}/bin/foobar"
+  chmod +x "${USER_HOME}/bin/foobar"
+
   run shell_wrapper
   assert_failure
   assert_output --partial "No  defined"
@@ -70,8 +74,13 @@ teardown() {
   assert_failure
   assert_output --partial "No foo defined"
 
-  # cannot test, the function is broken
-  # run shell_wrapper ls
-  # assert_success
-  # assert_output --partial "No foo defined"
+  run shell_wrapper ls
+  assert_success
+  assert [ -f "${BIN_DIR}/ls" ]
+  assert [ $(stat --format '%a' "${BIN_DIR}/ls") -eq 775 ]
+
+  PATH="${USER_HOME}/bin":$PATH run shell_wrapper foobar
+  assert_success
+  assert [ -f "${BIN_DIR}/foobar" ]
+  assert [ $(stat --format '%a' "${BIN_DIR}/ls") -eq 775 ]
 }


### PR DESCRIPTION
* Sets the correct path for shell wrappers
* Adds test for the shell wrapper
* sets the permissions to `775` for the shell wrappers

Closes #338 