### PR TITLE
fix: use new poetry install url

### DIFF
--- a/src/usr/local/buildpack/tools/poetry.sh
+++ b/src/usr/local/buildpack/tools/poetry.sh
@@ -10,7 +10,7 @@ if [[ ! "${MAJOR}" || ! "${MINOR}" || ! "${PATCH}" ]]; then
   exit 1
 fi
 
-POETRY_URL=https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py
+POETRY_URL=https://install.python-poetry.org
 
 tool_path=$(find_versioned_tool_path)
 


### PR DESCRIPTION
Moves the install url to the new location promoted by the poetry team.

Closes #339 