### PR TITLE
feat: abort on missing file url

### DIFF
--- a/src/usr/local/buildpack/tools/v2/flux.sh
+++ b/src/usr/local/buildpack/tools/v2/flux.sh
@@ -7,7 +7,13 @@ function install_tool () {
   local file
   local ARCH=amd64
   file=$(get_from_url "https://github.com/fluxcd/flux2/releases/download/v${TOOL_VERSION}/flux_${TOOL_VERSION}_linux_${ARCH}.tar.gz")
-  tar -C "${versioned_tool_path}" -zxvf "${file}"
+
+  if [[ -f ${file} ]]; then
+    tar -C "${versioned_tool_path}" -zxvf "${file}"
+  else
+    echo "No file found for version ${TOOL_VERSION}"
+    exit 1
+  fi
 }
 
 function link_tool () {

--- a/src/usr/local/buildpack/tools/v2/helm.sh
+++ b/src/usr/local/buildpack/tools/v2/helm.sh
@@ -8,7 +8,13 @@ function install_tool () {
 
   local file
   file=$(get_from_url "https://get.helm.sh/helm-v${TOOL_VERSION}-linux-amd64.tar.gz")
-  tar --strip 1 -C "${versioned_tool_path}/bin" -xf "${file}"
+
+  if [[ -f ${file} ]]; then
+    tar --strip 1 -C "${versioned_tool_path}/bin" -xf "${file}"
+  else
+    echo "No file found for version ${TOOL_VERSION}"
+    exit 1
+  fi
 }
 
 function link_tool () {

--- a/src/usr/local/buildpack/utils/cache.sh
+++ b/src/usr/local/buildpack/utils/cache.sh
@@ -40,9 +40,8 @@ function download_file () {
   name=${2:-$(basename "${url}")}
 
   local temp_folder=${BUILDPACK_CACHE_DIR:-${TEMP_DIR}}
-  if curl --create-dirs -sSfLo "${temp_folder}/${name}" "${url}" >/dev/null 2>&1 ; then
-    echo "${temp_folder}/${name}"
-  fi
+  curl --create-dirs -sSfLo "${temp_folder}/${name}" "${url}" >/dev/null 2>&1 || exit 1
+  echo "${temp_folder}/${name}"
 }
 
 # will try to clean up the oldest file in the cache until the cache is empty

--- a/src/usr/local/buildpack/utils/cache.sh
+++ b/src/usr/local/buildpack/utils/cache.sh
@@ -29,6 +29,9 @@ function get_from_url () {
 # Will download the file into the cache folder and returns the path
 # If the cache is not enabled it will download it to a temp folder
 # The second argument will be the filename if given
+#
+# If the download receives an error, the output will be given on stderr
+# and an empty string is returned
 function download_file () {
   local url=${1}
   check url true
@@ -37,8 +40,9 @@ function download_file () {
   name=${2:-$(basename "${url}")}
 
   local temp_folder=${BUILDPACK_CACHE_DIR:-${TEMP_DIR}}
-  curl --create-dirs -sSfLo "${temp_folder}/${name}" "${url}"
-  echo "${temp_folder}/${name}"
+  if curl --create-dirs -sSfLo "${temp_folder}/${name}" "${url}" >/dev/null 2>&1 ; then
+    echo "${temp_folder}/${name}"
+  fi
 }
 
 # will try to clean up the oldest file in the cache until the cache is empty

--- a/test/bash/cache.bats
+++ b/test/bash/cache.bats
@@ -201,6 +201,5 @@ teardown() {
   local file="https://github.com/containerbase/buildpack/releases/download/1.0.0/foobar"
 
   run get_from_url "${file}"
-  assert_success
-  assert_output ""
+  assert_failure
 }

--- a/test/bash/cache.bats
+++ b/test/bash/cache.bats
@@ -192,3 +192,15 @@ teardown() {
   assert_success
   assert_output --regexp "${BUILDPACK_CACHE_DIR}/[0-9a-f]{40}/test"
 }
+
+@test "get_from_url with errors" {
+  # create cache dir
+  BUILDPACK_CACHE_DIR="${TEST_ROOT_DIR}/cache"
+  mkdir -p "${BUILDPACK_CACHE_DIR}"
+
+  local file="https://github.com/containerbase/buildpack/releases/download/1.0.0/foobar"
+
+  run get_from_url "${file}"
+  assert_success
+  assert_output ""
+}

--- a/test/bash/tools/flux.bats
+++ b/test/bash/tools/flux.bats
@@ -102,6 +102,13 @@ teardown_file () {
   run flux -v
   assert_success
   assert_output --partial "${TOOL_VERSION}"
+
+  # don't update
+  TOOL_VERSION=0.26.999
+
+  run install_tool
+  assert_failure
+  assert_output -p "No file found"
 }
 
 @test "flux: link_tool" {

--- a/test/bash/tools/helm.bats
+++ b/test/bash/tools/helm.bats
@@ -102,6 +102,13 @@ teardown_file () {
   run helm version
   assert_success
   assert_output --partial "${TOOL_VERSION}"
+
+  # don't update
+  TOOL_VERSION=3.6.999
+
+  run install_tool
+  assert_failure
+  assert_output -p "No file found"
 }
 
 @test "helm: link_tool" {


### PR DESCRIPTION
Allows the cache to return non-existing file urls

This required for tools like python that will compile the binaries when no pre-build binaries are found