### PR TITLE
feat: use shell_wrapper for all v2 tools

### DIFF
--- a/src/usr/local/buildpack/tools/v2/flux.sh
+++ b/src/usr/local/buildpack/tools/v2/flux.sh
@@ -14,6 +14,6 @@ function link_tool () {
   local versioned_tool_path
   versioned_tool_path=$(find_versioned_tool_path)
 
-  link_wrapper "${TOOL_NAME}" "${versioned_tool_path}"
+  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}"
   flux -v
 }

--- a/src/usr/local/buildpack/tools/v2/helm.sh
+++ b/src/usr/local/buildpack/tools/v2/helm.sh
@@ -15,6 +15,6 @@ function link_tool () {
   local versioned_tool_path
   versioned_tool_path=$(find_versioned_tool_path)
 
-  link_wrapper "${TOOL_NAME}" "${versioned_tool_path}/bin"
+  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}/bin"
   helm version
 }

--- a/src/usr/local/buildpack/utils/linking.sh
+++ b/src/usr/local/buildpack/utils/linking.sh
@@ -2,26 +2,29 @@
 
 # use this if custom env is required, creates a shell wrapper to /usr/local/bin
 function shell_wrapper () {
-  local FILE
-  FILE="$(get_bin_path)/${1}"
-  check_command "$1"
-  cat > "$FILE" <<- EOM
+  local TARGET
+  local SOURCE=$2
+  TARGET="$(get_bin_path)/${1}"
+  if [[ -z "$SOURCE" ]]; then
+    SOURCE=$(command -v "${1}")
+  fi
+  if [[ -d "$SOURCE" ]]; then
+    SOURCE=$SOURCE/${1}
+  fi
+  check SOURCE true
+  check_command "$SOURCE"
+
+  cat > "$TARGET" <<- EOM
 #!/bin/bash
 
 if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
   . $ENV_FILE
 fi
 
-if [[ "\$(command -v ${1})" == "$FILE" ]]; then
-  echo Could not forward ${1}, probably wrong PATH variable. >&2
-  echo PATH=\$PATH
-  exit 1
-fi
-
-${1} "\$@"
+${SOURCE} "\$@"
 EOM
   # make it writable for the owner and the group
-  chmod 775 "$FILE"
+  chmod 775 "$TARGET"
 }
 
 # use this for simple symlink to /usr/local/bin

--- a/test/bash/linking.bats
+++ b/test/bash/linking.bats
@@ -68,11 +68,11 @@ teardown() {
 
   run shell_wrapper
   assert_failure
-  assert_output --partial "No  defined"
+  assert_output --partial "param SOURCE is set but empty"
 
   run shell_wrapper foo
   assert_failure
-  assert_output --partial "No foo defined"
+  assert_output --partial "param SOURCE is set but empty"
 
   run shell_wrapper ls
   assert_success


### PR DESCRIPTION
uses the `shell_wrapper` for all current v2 tools