### PR TITLE
fix: read v1 and v2 environment variables

### DIFF
--- a/src/usr/local/buildpack/tools/v2/erlang.sh
+++ b/src/usr/local/buildpack/tools/v2/erlang.sh
@@ -40,9 +40,6 @@ function prepare_tool() {
 
   local tool_path
   tool_path=$(create_tool_path)
-
-  # workaround https://github.com/containerbase/buildpack/issues/377
-  ln -sf "$tool_path" /usr/local/erlang
 }
 
 function install_tool () {

--- a/src/usr/local/buildpack/utils/environment.sh
+++ b/src/usr/local/buildpack/utils/environment.sh
@@ -80,27 +80,25 @@ function setup_env_files () {
   cat >> "$ENV_FILE" <<- EOM
 export BUILDPACK=1 USER_NAME="${USER_NAME}" USER_ID="${USER_ID}" USER_HOME="${USER_HOME}"
 
+env_dirs=("/usr/local" "/opt/buildpack" "\${USER_HOME}")
+
 # openshift override unknown user home
 if [ "\${EUID}" != 0 ]; then
   export HOME="\${USER_HOME}"
 fi
 
-if [ -d "${install_dir}/env.d" ]; then
-  for i in "${install_dir}/env.d"/*.sh; do
-    if [ -r \$i ]; then
-      . \$i
-    fi
-  done
-  unset i
-fi
-if [ -d "${USER_HOME}/env.d" ]; then
-  for i in "${USER_HOME}/env.d"/*.sh; do
-    if [ -r \$i ]; then
-      . \$i
-    fi
-  done
-  unset i
-fi
+for p in \${env_dirs[@]}; do
+  echo "\${p}"
+  if [ -d "\${p}/env.d" ]; then
+    for i in "\${p}/env.d"/*.sh; do
+      if [ -r \$i ]; then
+        . \$i
+      fi
+    done
+    unset i
+  fi
+done
+
 EOM
 
   cat >> "${BASH_RC}" <<- EOM

--- a/src/usr/local/buildpack/utils/environment.sh
+++ b/src/usr/local/buildpack/utils/environment.sh
@@ -88,7 +88,6 @@ if [ "\${EUID}" != 0 ]; then
 fi
 
 for p in \${env_dirs[@]}; do
-  echo "\${p}"
   if [ -d "\${p}/env.d" ]; then
     for i in "\${p}/env.d"/*.sh; do
       if [ -r \$i ]; then
@@ -98,6 +97,8 @@ for p in \${env_dirs[@]}; do
     unset i
   fi
 done
+unset p
+unset env_dirs
 
 EOM
 


### PR DESCRIPTION
Reads the environment for v1 and v2 tools as well as the user directory
Priority list from least to most priority:
* `/usr/local/env.d/`
* `/opt/buildpack/env.d/`
* `${USER_HOME}/env.d/`

Closes #377