### PR TITLE
chore: allow bats tests to use a global cache dir

### DIFF
--- a/test/bash/cache.sh
+++ b/test/bash/cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Create a temp directory for the test or use
+# the global one if defined in the given var.
+# Returns the path to the temp directory
+#
+# The caller is responible to create the
+# folder in the given var if it is set
+function create_temp_dir () {
+  local global_var=$1
+
+  if [[ -z "${!global_var}" ]]; then
+    temp_dir="$(mktemp -u)"
+    # shellcheck disable=SC2174
+    mkdir -m 777 -p "${temp_dir}" >/dev/null 2>&1
+    echo "${temp_dir}"
+  else
+    echo "${!global_var}"
+  fi
+}
+
+# Removes the temp dir in the first var
+# if it is created for the test
+# If the global env is set, nothing will be done
+function clean_temp_dir () {
+  local temp_dir=$1
+  local global_var=$2
+
+  if [[ -z "${!global_var}" ]]; then
+    rm -rf "${temp_dir}"
+  fi
+}

--- a/test/bash/tools/flux.bats
+++ b/test/bash/tools/flux.bats
@@ -1,18 +1,16 @@
 setup_file () {
+  export TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+
   # set up the cache
-  BUILDPACK_CACHE_DIR="$(mktemp -u)"
-  mkdir -m 777 -p "${BUILDPACK_CACHE_DIR}"
+  load "$TEST_DIR/../cache.sh"
+  export BUILDPACK_CACHE_DIR="$(create_temp_dir TEST_CACHE_DIR)"
 }
 
 setup() {
   load '../../../node_modules/bats-support/load'
   load '../../../node_modules/bats-assert/load'
 
-  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
   TEST_ROOT_DIR=$(mktemp -u)
-
-  echo $TEST_DIR
-  echo $BATS_TEST_FILENAME
 
   load "$TEST_DIR/../../../src/usr/local/buildpack/util.sh"
 
@@ -41,7 +39,7 @@ teardown() {
 }
 
 teardown_file () {
-  rm -rf "${BUILDPACK_CACHE_DIR}"
+  clean_temp_dir $BUILDPACK_CACHE_DIR TEST_CACHE_DIR
 }
 
 @test "flux: check_tool_requirements" {

--- a/test/bash/tools/helm.bats
+++ b/test/bash/tools/helm.bats
@@ -1,18 +1,16 @@
 setup_file () {
+  export TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+
   # set up the cache
-  BUILDPACK_CACHE_DIR="$(mktemp -u)"
-  mkdir -m 777 -p "${BUILDPACK_CACHE_DIR}"
+  load "$TEST_DIR/../cache.sh"
+  export BUILDPACK_CACHE_DIR="$(create_temp_dir TEST_CACHE_DIR)"
 }
 
 setup() {
   load '../../../node_modules/bats-support/load'
   load '../../../node_modules/bats-assert/load'
 
-  TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
   TEST_ROOT_DIR=$(mktemp -u)
-
-  echo $TEST_DIR
-  echo $BATS_TEST_FILENAME
 
   load "$TEST_DIR/../../../src/usr/local/buildpack/util.sh"
 
@@ -41,7 +39,7 @@ teardown() {
 }
 
 teardown_file () {
-  rm -rf "${BUILDPACK_CACHE_DIR}"
+  clean_temp_dir $BUILDPACK_CACHE_DIR TEST_CACHE_DIR
 }
 
 @test "helm: check_tool_requirements" {


### PR DESCRIPTION
Example usage for local testing:
```bash
export TEST_CACHE_DIR=/tmp/renovate/bats
yarn bats
```
Reduces the bats testing from 16 to 6 seconds when the cache if filled.