### PR TITLE
fix(erlang): support v22 and skip non-required system deps

### DIFF
--- a/src/usr/local/buildpack/tools/v2/erlang.sh
+++ b/src/usr/local/buildpack/tools/v2/erlang.sh
@@ -19,36 +19,27 @@ function check_tool_requirements () {
     echo Invalid version: "${TOOL_VERSION}"
     exit 1
   fi
-}
 
-function prepare_tool() {
   local version_codename
-
-  version_codename=$(get_distro)
-  case "$version_codename" in
-    "bionic") #apt_install \
-      #libodbc1 \
-      #libssl1.1 \
-      #libsctp1 \
-      ;;
-    "focal") #apt_install \
-      #libodbc1 \
-      #libssl1.1 \
-      #libsctp1 \
-      ;;
-    "jammy") #apt_install \
-      #libodbc1 \
-      #libssl3 \
-      #libsctp1 \
-      ;;
+  version_codename="$(get_distro)"
+  case "${version_codename}" in
+    "bionic");;
+    "focal");;
+    "jammy");;
     *)
       echo "Tool '${TOOL_NAME}' not supported on: ${version_codename}! Please use ubuntu 'bionic', 'focal' or 'jammy'." >&2
       exit 1
     ;;
   esac
+}
 
+function prepare_tool() {
   local tool_path
   tool_path=$(create_tool_path)
+  # Workaround for compatibillity for Erlang hardcoded paths, works for v22+
+  if [ "${tool_path}" != "${ROOT_DIR_LEGACY}/erlang" ]; then
+    ln -sf "${tool_path}" /usr/local/erlang
+  fi
 }
 
 function install_tool () {
@@ -81,7 +72,8 @@ function link_tool () {
   local versioned_tool_path
   versioned_tool_path=$(find_versioned_tool_path)
 
-  export_tool_env ERL_ROOTDIR "${versioned_tool_path}"
+  # only works for v24+
+  #export_tool_env ERL_ROOTDIR "${versioned_tool_path}"
   shell_wrapper erl "${versioned_tool_path}/bin"
   erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell
 }

--- a/src/usr/local/buildpack/tools/v2/erlang.sh
+++ b/src/usr/local/buildpack/tools/v2/erlang.sh
@@ -26,20 +26,20 @@ function prepare_tool() {
 
   version_codename=$(get_distro)
   case "$version_codename" in
-    "bionic") apt_install \
-      libodbc1 \
-      libssl1.1 \
-      libsctp1 \
+    "bionic") #apt_install \
+      #libodbc1 \
+      #libssl1.1 \
+      #libsctp1 \
       ;;
-    "focal") apt_install \
-      libodbc1 \
-      libssl1.1 \
-      libsctp1 \
+    "focal") #apt_install \
+      #libodbc1 \
+      #libssl1.1 \
+      #libsctp1 \
       ;;
-    "jammy") apt_install \
-      libodbc1 \
-      libssl3 \
-      libsctp1 \
+    "jammy") #apt_install \
+      #libodbc1 \
+      #libssl3 \
+      #libsctp1 \
       ;;
     *)
       echo "Tool '${TOOL_NAME}' not supported on: ${version_codename}! Please use ubuntu 'bionic', 'focal' or 'jammy'." >&2

--- a/src/usr/local/buildpack/utils/v2/overrides.sh
+++ b/src/usr/local/buildpack/utils/v2/overrides.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# defines the legacy root directory where old tools will be installed
+# reguired for some legacy tools for bat test redirection
+export ROOT_DIR_LEGACY="${ROOT_DIR}"
+
 # OVERWRITE:
 #
 # defines the root directory where tools will be installed

--- a/test/erlang/Dockerfile
+++ b/test/erlang/Dockerfile
@@ -16,6 +16,7 @@ FROM build as testa
 ARG APT_HTTP_PROXY
 ARG BUILDPACK_DEBUG
 
+# https://hexdocs.pm/elixir/1.13.4/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
 # renovate: datasource=github-releases lookupName=containerbase/erlang-prebuild versioning=docker
 RUN install-tool erlang 24.3.4.2
 
@@ -42,6 +43,7 @@ RUN prepare-tool erlang
 
 USER 1001
 
+# https://hexdocs.pm/elixir/1.13.4/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
 # renovate: datasource=github-releases lookupName=containerbase/erlang-prebuild versioning=docker
 RUN install-tool erlang 24.3.4.2
 
@@ -68,6 +70,7 @@ RUN prepare-tool erlang
 
 USER 1001
 
+# https://hexdocs.pm/elixir/1.13.4/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
 # no major update, pin elixir if newer version doesn't support v22
 # renovate: datasource=github-releases lookupName=containerbase/erlang-prebuild versioning=docker
 RUN install-tool erlang 22.3.4.26

--- a/test/erlang/Dockerfile
+++ b/test/erlang/Dockerfile
@@ -57,9 +57,36 @@ RUN set -ex; \
 
 
 #--------------------------------------
+# test: erlang (v22,user,openshift)
+#--------------------------------------
+FROM build as testc
+
+ARG APT_HTTP_PROXY
+ARG BUILDPACK_DEBUG
+
+RUN prepare-tool erlang
+
+USER 1001
+
+# no major update, pin elixir if newer version doesn't support v22
+# renovate: datasource=github-releases lookupName=containerbase/erlang-prebuild versioning=docker
+RUN install-tool erlang 22.3.4.26
+
+ARG BUILDPACK_DEBUG
+
+# renovate: datasource=docker versioning=docker
+RUN install-tool elixir 1.13.4
+
+
+RUN set -ex; \
+    cd a; \
+    mix deps.update --all;
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM build
 
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
+COPY --from=testc /.dummy /.dummy


### PR DESCRIPTION
- readd support for erlang v22
- skip system deps, they aren't required