### PR TITLE
fix: allow linking an already installed version

### DIFF
--- a/src/usr/local/buildpack/tools/v2/python.sh
+++ b/src/usr/local/buildpack/tools/v2/python.sh
@@ -95,8 +95,6 @@ function install_tool () {
 function link_tool () {
   local versioned_tool_path
   versioned_tool_path=$(find_versioned_tool_path)
-  
-  check_semver "${TOOL_VERSION}"
 
   reset_tool_env
 

--- a/src/usr/local/buildpack/tools/v2/python.sh
+++ b/src/usr/local/buildpack/tools/v2/python.sh
@@ -95,6 +95,8 @@ function install_tool () {
 function link_tool () {
   local versioned_tool_path
   versioned_tool_path=$(find_versioned_tool_path)
+  
+  check_semver "${TOOL_VERSION}"
 
   reset_tool_env
 

--- a/src/usr/local/buildpack/utils/install.sh
+++ b/src/usr/local/buildpack/utils/install.sh
@@ -12,9 +12,10 @@ function install_v2_tool () {
   # shellcheck source=/dev/null
   . "${path}"
 
+  check_tool_requirements
+
   if ! check_tool_installed; then
     echo "installing v2 tool ${TOOL_NAME} v${TOOL_VERSION}"
-    check_tool_requirements
     install_tool
   else
     echo "tool ${TOOL_NAME} v${TOOL_VERSION} is already installed"

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -162,8 +162,7 @@ RUN set -ex \
 #--------------------------------------
 # test h: pipenv (multiple python)
 #--------------------------------------
-FROM base as testh
-# use build when #462 is fixed
+FROM build as testh
 
 ARG BUILDPACK_DEBUG
 
@@ -182,25 +181,6 @@ RUN set -ex; \
   pipenv lock;
 
 #--------------------------------------
-# test i: relink previously installed python
-#--------------------------------------
-FROM build as testi
-
-ARG BUILDPACK_DEBUG
-
-# install some versions of python
-RUN install-tool python 3.8.0
-RUN install-tool python 3.9.0
-
-# install back the previous version to relink it
-RUN install-tool python 3.8.0
-
-USER 1000
-
-SHELL [ "/bin/sh", "-c" ]
-RUN python --version | grep 3.8.0
-
-#--------------------------------------
 # final
 #--------------------------------------
 FROM build
@@ -213,4 +193,3 @@ COPY --from=teste /.dummy /.dummy
 COPY --from=testf /.dummy /.dummy
 COPY --from=testg /.dummy /.dummy
 COPY --from=testh /.dummy /.dummy
-COPY --from=testi /.dummy /.dummy

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -181,6 +181,24 @@ RUN set -ex; \
   cd h-pipenv; \
   pipenv lock;
 
+#--------------------------------------
+# test i: relink previously installed python
+#--------------------------------------
+FROM build as testi
+
+ARG BUILDPACK_DEBUG
+
+# install some versions of python
+RUN install-tool python 3.8.0
+RUN install-tool python 3.9.0
+
+# install back the previous version to relink it
+RUN install-tool python 3.8.0
+
+USER 1000
+
+SHELL [ "/bin/sh", "-c" ]
+RUN python --version | grep 3.8.0
 
 #--------------------------------------
 # final
@@ -195,3 +213,4 @@ COPY --from=teste /.dummy /.dummy
 COPY --from=testf /.dummy /.dummy
 COPY --from=testg /.dummy /.dummy
 COPY --from=testh /.dummy /.dummy
+COPY --from=testi /.dummy /.dummy


### PR DESCRIPTION
While installing an already present version of python with `install-tool`, the linking process fails (if it is called, i.e. if there is a mismatch between the current version and the one to be installed) because the `MAJOR` and `MINOR` env variables are not set and the constructed path is invalid:

```bash
# src/usr/local/buildpack/tools/v2/python.sh
function link_tool () {
  ...
  python_shell_wrapper "${TOOL_NAME}${MAJOR}" "${versioned_tool_path}"
  python_shell_wrapper "${TOOL_NAME}${MAJOR}.${MINOR}" "${versioned_tool_path}"
```

These variables are set by the `check_semver` function, that is called by the `check_tool_requirements` in the `install_v2_tool` (`src/usr/local/buildpack/utils/install.sh`), but that invocation is skipped when the tool is already present and only requires linking.

This change adds a suitable test and the `check_semver` call in the `link_tool` definition for python to address this issue.

- fixes https://github.com/containerbase/buildpack/issues/462