### PR TITLE
fix: Revert "fix: log unsupported error and exit on arm64 and `focal` (#5718)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
+          - focal
           - jammy
 
     env:

--- a/src/usr/local/containerbase/util.sh
+++ b/src/usr/local/containerbase/util.sh
@@ -148,12 +148,7 @@ function require_arch () {
 
 function require_distro () {
   case "$DISTRO_CODENAME" in
-  "focal") #supported (only amd64)
-    if [[ "$ARCHITECTURE" != "x86_64" ]]; then
-      echo "Distro 'focal' only supported on 'x86_64' arch!" >&2
-      exit 1
-    fi
-  ;;
+  "focal") ;; #supported
   "jammy") ;; #supported
   "noble") ;; #supported
   *)


### PR DESCRIPTION
it should work again after pkg v6.12 update

- https://github.com/containerbase/base/pull/5759
- https://github.com/yao-pkg/pkg-fetch/pull/142