### PR TITLE
fix: call `process.exit` to force shutdown

### DIFF
--- a/src/cli/main.spec.ts
+++ b/src/cli/main.spec.ts
@@ -4,6 +4,7 @@ import { main } from './main';
 const mocks = vi.hoisted(() => ({
   argv0: 'containerbase-cli',
   argv: ['node', 'containerbase-cli', 'help'],
+  exit: vi.fn(),
 }));
 
 vi.mock('node:process', async (importOriginal) => ({
@@ -20,5 +21,6 @@ describe('cli/main', () => {
   test('works', async () => {
     vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     expect(await main()).toBeUndefined();
+    expect(mocks.exit).toHaveBeenCalled();
   });
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,4 @@
-import { argv, argv0, version } from 'node:process';
+import { argv, argv0, exit, version } from 'node:process';
 import { Builtins, Cli } from 'clipanion';
 import { registerCommands } from './command';
 import { bootstrap } from './proxy';
@@ -31,5 +31,6 @@ export async function main(): Promise<void> {
 
   registerCommands(cli, mode);
 
-  await cli.runExit(args);
+  // Explicitly call exit to force pino shutdown
+  exit(await cli.run(args));
 }


### PR DESCRIPTION
It seems nodejs sometimes get stuck and didn't emit exit event and then pino causes to not exit.
We now explicit call `process.exit` to emit the event and force node exiting.

- https://github.com/pinojs/pino/issues/2002