### PR TITLE
feat(java/maven): use maven repo as fallback source

### DIFF
--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -403,7 +403,7 @@ https://services.gradle.org/distributions/gradle-6.9.4-bin.zip
 Maven releases are downloaded from:
 
 - `https://github.com/containerbase/maven-prebuild/releases`
-- `https://archive.apache.org/dist/maven`
+- `https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven`
 
 The first url is preferred and the second is used as fallback for older versions.
 
@@ -413,10 +413,10 @@ Samples:
 https://github.com/containerbase/maven-prebuild/releases/download/3.0.4/maven-3.0.4.tar.xz.sha512
 https://github.com/containerbase/maven-prebuild/releases/download/3.0.4/maven-3.0.4.tar.xz
 https://github.com/containerbase/maven-prebuild/releases/latest/download/version
-https://archive.apache.org/dist/maven/maven-3/3.0.4/binaries/apache-maven-3.0.4-bin.tar.gz
-https://archive.apache.org/dist/maven/maven-3/3.0.4/binaries/apache-maven-3.0.4-bin.tar.gz.sha1
-https://archive.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar
-https://archive.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz.sha512
+https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.4/apache-maven-3.0.4-bin.tar.gz
+https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.4/apache-maven-3.0.4-bin.tar.gz.sha1
+https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.tar
+https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.tar.gz.sha512
 ```
 
 ### `sbt`

--- a/src/cli/tools/java/maven.ts
+++ b/src/cli/tools/java/maven.ts
@@ -35,12 +35,12 @@ export class MavenInstallService extends BaseInstallService {
         expectedChecksum,
       });
     } else {
-      logger.info(`using archive.apache.org`);
+      logger.info(`using repo.maven.apache.org`);
       strip = 1;
-      // fallback to archive.apache.org
+      // fallback to repo.maven.apache.org
       const ver = parse(version);
       filename = `apache-${name}-${version}-bin.tar.gz`;
-      url = `https://archive.apache.org/dist/${name}/${name}-${ver.major}/${ver.version}/binaries/${filename}`;
+      url = `https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${ver.version}/${filename}`;
       checksumFileUrl = `${url}.sha512`;
       let expectedChecksum: string | undefined;
       let checksumType: HttpChecksumType | undefined;


### PR DESCRIPTION
That repo is much faster updated and the official source for the maven wrapper.

⚠️  Can be breaking for some users when the version isn't on github and they block maven repo. ⚠️ 