### PR TITLE
fix(bun): use baseline if current amd64 cpu is missing avx2

### DIFF
--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -67,6 +67,7 @@ Samples:
 
 ```txt
 https://github.com/oven-sh/bun/releases/download/bun-v1.0.0/bun-linux-x64.zip
+https://github.com/oven-sh/bun/releases/download/bun-v1.0.0/bun-linux-x64-baseline.zip
 https://github.com/oven-sh/bun/releases/download/bun-v1.0.0/bun-linux-aarch64.zip
 https://github.com/oven-sh/bun/releases/download/bun-v1.0.0/SHASUMS256.txt
 ```

--- a/src/cli/tools/bun.ts
+++ b/src/cli/tools/bun.ts
@@ -19,7 +19,20 @@ export class BunInstallService extends BaseInstallService {
 
   override async install(version: string): Promise<void> {
     const baseUrl = `https://github.com/oven-sh/bun/releases/download/bun-v${version}/`;
-    const filename = `bun-linux-${this.ghArch}.zip`;
+    let { ghArch } = this;
+
+    if (ghArch === 'x64') {
+      try {
+        const cpuInfo = await fs.readFile('/proc/cpuinfo', 'utf-8');
+        if (!cpuInfo.includes('avx2')) {
+          ghArch = 'x64-baseline';
+        }
+      } catch {
+        ghArch = 'x64-baseline';
+      }
+    }
+
+    const filename = `bun-linux-${ghArch}.zip`;
 
     const checksumFile = await this.http.download({
       url: `${baseUrl}SHASUMS256.txt`,


### PR DESCRIPTION
Use bun baseline if avx2 is missing on install time for amd64. It'll still crash on runtime when the image is built with avx2 support but runtime cpu doesn't have it.

- https://github.com/renovatebot/renovate/discussions/42644