### PR TITLE
ci: fix trivy action tag

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           show-progress: false
 
-      - uses: aquasecurity/trivy-action@8aa8af3ea1de8e968a3e49a40afb063692ab8eae # 0.10.0
+      - uses: aquasecurity/trivy-action@8aa8af3ea1de8e968a3e49a40afb063692ab8eae # v0.10.0
         with:
           image-ref: 'ghcr.io/containerbase/base:latest'
           format: 'sarif'


### PR DESCRIPTION
broken by 
- #965
- https://github.com/aquasecurity/trivy-action/releases/tag/v0.10.0